### PR TITLE
Project Page Mutations

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -25,12 +25,6 @@ const pandaConfig = defineConfig({
       },
     ],
   },
-  globalVars: {
-    extend: {
-      "--scrollable-mask":
-        "linear-gradient(to bottom, rgba(0,0,0,1) 80%, rgba(0,0,0,0))",
-    },
-  },
   globalCss: {
     extend: {
       html: {
@@ -73,6 +67,12 @@ const pandaConfig = defineConfig({
         },
       },
       tokens: {
+        gradients: {
+          mask: {
+            value:
+              "linear-gradient(to bottom, transparent 5%, {colors.background.default})",
+          },
+        },
         sizes: {
           18: { value: "4.5rem" },
           header: { value: "5rem" },

--- a/src/app/organizations/[organizationSlug]/projects/[projectSlug]/[feedbackId]/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/[projectSlug]/[feedbackId]/page.tsx
@@ -7,12 +7,10 @@ import { Page } from "components/layout";
 import {
   Role,
   useCommentsQuery,
-  useDownvoteQuery,
   useFeedbackByIdQuery,
   useInfiniteCommentsQuery,
   useOrganizationRoleQuery,
   useProjectStatusesQuery,
-  useUpvoteQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
 import { getSdk } from "lib/graphql";
@@ -110,29 +108,9 @@ const FeedbackPage = async ({ params }: Props) => {
         organizationId: feedback.project?.organization?.rowId!,
       }),
     }),
-    queryClient.prefetchQuery({
-      queryKey: useDownvoteQuery.getKey({
-        userId: session?.user?.rowId!,
-        feedbackId,
-      }),
-      queryFn: useDownvoteQuery.fetcher({
-        userId: session?.user?.rowId!,
-        feedbackId,
-      }),
-    }),
-    queryClient.prefetchQuery({
-      queryKey: useUpvoteQuery.getKey({
-        userId: session?.user?.rowId!,
-        feedbackId,
-      }),
-      queryFn: useUpvoteQuery.fetcher({
-        userId: session?.user?.rowId!,
-        feedbackId,
-      }),
-    }),
     queryClient.prefetchInfiniteQuery({
-      queryKey: useInfiniteCommentsQuery.getKey({ pageSize: 5, feedbackId }),
-      queryFn: useCommentsQuery.fetcher({ pageSize: 5, feedbackId }),
+      queryKey: useInfiniteCommentsQuery.getKey({ feedbackId }),
+      queryFn: useCommentsQuery.fetcher({ feedbackId }),
       initialPageParam: undefined,
     }),
   ]);

--- a/src/app/organizations/[organizationSlug]/projects/[projectSlug]/[feedbackId]/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/[projectSlug]/[feedbackId]/page.tsx
@@ -140,9 +140,10 @@ const FeedbackPage = async ({ params }: Props) => {
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <Page breadcrumbs={breadcrumbs}>
-        <FeedbackDetails feedbackId={feedbackId} />
+        <FeedbackDetails user={session.user} feedbackId={feedbackId} />
 
         <Comments
+          user={session.user}
           organizationId={feedback.project?.organization?.rowId!}
           feedbackId={feedbackId}
         />

--- a/src/app/organizations/[organizationSlug]/projects/[projectSlug]/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/[projectSlug]/page.tsx
@@ -102,14 +102,12 @@ const ProjectPage = async ({ params, searchParams }: Props) => {
     }),
     queryClient.prefetchInfiniteQuery({
       queryKey: useInfinitePostsQuery.getKey({
-        pageSize: 5,
         projectId: project.rowId,
         excludedStatuses,
         orderBy: orderBy ? (orderBy as PostOrderBy) : undefined,
         search,
       }),
       queryFn: usePostsQuery.fetcher({
-        pageSize: 5,
         projectId: project.rowId,
         excludedStatuses,
         orderBy: orderBy ? (orderBy as PostOrderBy) : undefined,

--- a/src/app/organizations/[organizationSlug]/projects/[projectSlug]/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/[projectSlug]/page.tsx
@@ -9,6 +9,7 @@ import { ProjectOverview } from "components/project";
 import {
   Role,
   useInfinitePostsQuery,
+  useOrganizationRoleQuery,
   usePostsQuery,
   useProjectMetricsQuery,
   useProjectQuery,
@@ -117,6 +118,16 @@ const ProjectPage = async ({ params, searchParams }: Props) => {
       initialPageParam: undefined,
     }),
     queryClient.prefetchQuery({
+      queryKey: useOrganizationRoleQuery.getKey({
+        userId: session.user.rowId!,
+        organizationId: project.organization?.rowId!,
+      }),
+      queryFn: useOrganizationRoleQuery.fetcher({
+        userId: session.user.rowId!,
+        organizationId: project.organization?.rowId!,
+      }),
+    }),
+    queryClient.prefetchQuery({
       queryKey: useProjectMetricsQuery.getKey({ projectId: project.rowId }),
       queryFn: useProjectMetricsQuery.fetcher({ projectId: project.rowId }),
     }),
@@ -162,7 +173,7 @@ const ProjectPage = async ({ params, searchParams }: Props) => {
           ],
         }}
       >
-        <ProjectOverview projectId={project.rowId} />
+        <ProjectOverview user={session.user} projectId={project.rowId} />
       </Page>
     </HydrationBoundary>
   );

--- a/src/components/core/GradientMask/GradientMask.tsx
+++ b/src/components/core/GradientMask/GradientMask.tsx
@@ -1,0 +1,16 @@
+import { Box } from "@omnidev/sigil";
+
+import type { BoxProps } from "@omnidev/sigil";
+
+const GradientMask = (props: BoxProps) => (
+  <Box
+    position="absolute"
+    h={24}
+    w="full"
+    bgGradient="mask"
+    pointerEvents="none"
+    {...props}
+  />
+);
+
+export default GradientMask;

--- a/src/components/core/GradientMask/GradientMask.tsx
+++ b/src/components/core/GradientMask/GradientMask.tsx
@@ -2,6 +2,9 @@ import { Box } from "@omnidev/sigil";
 
 import type { BoxProps } from "@omnidev/sigil";
 
+/**
+ * Gradient mask component. Used to provide a fade-out effect for scrollable containers.
+ */
 const GradientMask = (props: BoxProps) => (
   <Box
     position="absolute"

--- a/src/components/core/index.ts
+++ b/src/components/core/index.ts
@@ -12,6 +12,7 @@ export {
   default as DestructiveAction,
   type Props as DestructiveActionProps,
 } from "./DestructiveAction/DestructiveAction";
+export { default as GradientMask } from "./GradientMask/GradientMask";
 export { default as Image } from "./Image/Image";
 export { default as Link } from "./Link/Link";
 export { default as LogoLink } from "./LogoLink/LogoLink";

--- a/src/components/dashboard/RecentFeedback/RecentFeedback.tsx
+++ b/src/components/dashboard/RecentFeedback/RecentFeedback.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Box, Flex, Stack, Text, VStack } from "@omnidev/sigil";
+import { Flex, Stack, Text, VStack } from "@omnidev/sigil";
 import useInfiniteScroll from "react-infinite-scroll-hook";
 
-import { Link, SkeletonArray, Spinner } from "components/core";
+import { GradientMask, Link, SkeletonArray, Spinner } from "components/core";
 import { FeedbackSection, Response } from "components/dashboard";
 import { EmptyState, ErrorBoundary } from "components/layout";
 import { useInfiniteRecentFeedbackQuery } from "generated/graphql";
@@ -52,7 +52,6 @@ const RecentFeedback = () => {
       maxH="xl"
       contentProps={{
         overflow: "auto",
-        p: 2,
         scrollbar: "hidden",
       }}
     >
@@ -69,14 +68,9 @@ const RecentFeedback = () => {
           {isLoading ? (
             <SkeletonArray count={5} h={24} w="100%" />
           ) : recentFeedback?.length ? (
-            <VStack>
+            <VStack gap={0} p={1}>
               {recentFeedback?.map((feedback) => (
-                <Flex
-                  key={feedback?.rowId}
-                  direction="column"
-                  w="full"
-                  _last={{ pb: 2 }}
-                >
+                <Flex key={feedback?.rowId} direction="column" w="full" p={1}>
                   <Link
                     href={`/organizations/${feedback?.project?.organization?.slug}/projects/${feedback?.project?.slug}/${feedback?.rowId}`}
                   >
@@ -85,7 +79,7 @@ const RecentFeedback = () => {
                       p={2}
                       _hover={{
                         bgColor: "background.muted/40",
-                        borderRadius: "md",
+                        borderRadius: "sm",
                       }}
                     />
                   </Link>
@@ -109,16 +103,7 @@ const RecentFeedback = () => {
             />
           )}
 
-          {!!recentFeedback.length && (
-            <Box
-              position="absolute"
-              bottom={0}
-              h={12}
-              w="full"
-              bgGradient="mask"
-              pointerEvents="none"
-            />
-          )}
+          {!!recentFeedback.length && <GradientMask bottom={0} />}
         </Stack>
       )}
     </FeedbackSection>

--- a/src/components/dashboard/RecentFeedback/RecentFeedback.tsx
+++ b/src/components/dashboard/RecentFeedback/RecentFeedback.tsx
@@ -116,6 +116,7 @@ const RecentFeedback = () => {
               h={12}
               w="full"
               bgGradient="mask"
+              pointerEvents="none"
             />
           )}
         </Stack>

--- a/src/components/dashboard/Response/Response.tsx
+++ b/src/components/dashboard/Response/Response.tsx
@@ -27,8 +27,14 @@ const Response = ({ feedback, ...rest }: Props) => {
   return (
     <Stack gap={4} w="100%" {...rest}>
       <Stack gap={2}>
-        <Flex align="center" justify="space-between">
-          <Text fontWeight="semibold" fontSize="sm" mb={1}>
+        <Flex justify="space-between">
+          <Text
+            fontWeight="semibold"
+            fontSize="sm"
+            mb={1}
+            // TODO: figure out container queries for this.
+            maxW={{ base: "25svw", xl: "md" }}
+          >
             {feedback?.title}
           </Text>
 

--- a/src/components/feedback/CommentCard/CommentCard.tsx
+++ b/src/components/feedback/CommentCard/CommentCard.tsx
@@ -66,7 +66,6 @@ const CommentCard = ({
       onSettled: () =>
         queryClient.invalidateQueries({
           queryKey: useInfiniteCommentsQuery.getKey({
-            pageSize: 5,
             feedbackId,
           }),
         }),

--- a/src/components/feedback/CommentCard/CommentCard.tsx
+++ b/src/components/feedback/CommentCard/CommentCard.tsx
@@ -11,12 +11,15 @@ import {
   useInfiniteCommentsQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
-import { useAuth, useOrganizationMembership } from "lib/hooks";
+import { useOrganizationMembership } from "lib/hooks";
 
 import type { StackProps } from "@omnidev/sigil";
 import type { Comment, Organization } from "generated/graphql";
+import type { Session } from "next-auth";
 
 interface Props extends StackProps {
+  /** Authenticated user. */
+  user: Session["user"];
   /** Organization ID. */
   organizationId: Organization["rowId"];
   /** Comment ID. */
@@ -37,6 +40,7 @@ interface Props extends StackProps {
  * Comment card.
  */
 const CommentCard = ({
+  user,
   organizationId,
   commentId,
   senderName,
@@ -46,8 +50,6 @@ const CommentCard = ({
   isSender = false,
   ...rest
 }: Props) => {
-  const { user } = useAuth();
-
   const queryClient = useQueryClient();
 
   const { feedbackId } = useParams<{

--- a/src/components/feedback/Comments/Comments.tsx
+++ b/src/components/feedback/Comments/Comments.tsx
@@ -13,7 +13,6 @@ import {
   useInfiniteCommentsQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
-import { useAuth } from "lib/hooks";
 
 import type {
   CommentFragment,
@@ -21,8 +20,11 @@ import type {
   Organization,
   Post,
 } from "generated/graphql";
+import type { Session } from "next-auth";
 
 interface Props {
+  /** Authenticated user. */
+  user: Session["user"];
   /** Organization ID. */
   organizationId: Organization["rowId"];
   /** Feedback ID. */
@@ -32,9 +34,7 @@ interface Props {
 /**
  * Feedback comments section.
  */
-const Comments = ({ organizationId, feedbackId }: Props) => {
-  const { user } = useAuth();
-
+const Comments = ({ user, organizationId, feedbackId }: Props) => {
   const { data, isLoading, isError, hasNextPage, fetchNextPage } =
     useInfiniteCommentsQuery(
       {
@@ -124,6 +124,7 @@ const Comments = ({ organizationId, feedbackId }: Props) => {
                   return (
                     <CommentCard
                       key={comment?.rowId}
+                      user={user}
                       organizationId={organizationId}
                       commentId={comment?.rowId!}
                       senderName={comment?.user?.username}

--- a/src/components/feedback/Comments/Comments.tsx
+++ b/src/components/feedback/Comments/Comments.tsx
@@ -100,7 +100,7 @@ const Comments = ({ user, organizationId, feedbackId }: Props) => {
         <CreateComment />
 
         {isError ? (
-          <ErrorBoundary message="Error fetching comments" h="xs" />
+          <ErrorBoundary message="Error fetching comments" h="xs" my={4} />
         ) : (
           // NB: the padding is necessary to prevent clipping of the card borders/box shadows
           <Grid

--- a/src/components/feedback/Comments/Comments.tsx
+++ b/src/components/feedback/Comments/Comments.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Box, Grid, Stack, Text, VStack } from "@omnidev/sigil";
+import { Grid, Stack, Text, VStack } from "@omnidev/sigil";
 import { useMutationState } from "@tanstack/react-query";
 import { LuMessageSquare } from "react-icons/lu";
 import useInfiniteScroll from "react-infinite-scroll-hook";
 
-import { SkeletonArray, Spinner } from "components/core";
+import { GradientMask, SkeletonArray, Spinner } from "components/core";
 import { CommentCard, CreateComment } from "components/feedback";
 import { EmptyState, ErrorBoundary, SectionContainer } from "components/layout";
 import {
@@ -38,7 +38,6 @@ const Comments = ({ user, organizationId, feedbackId }: Props) => {
   const { data, isLoading, isError, hasNextPage, fetchNextPage } =
     useInfiniteCommentsQuery(
       {
-        pageSize: 5,
         feedbackId,
       },
       {
@@ -103,7 +102,7 @@ const Comments = ({ user, organizationId, feedbackId }: Props) => {
         {isError ? (
           <ErrorBoundary message="Error fetching comments" h="xs" my={4} />
         ) : (
-          <Grid gap={2} mt={4} maxH="sm" overflow="auto" scrollbar="hidden">
+          <Grid gap={2} mt={4} maxH="md" overflow="auto" scrollbar="hidden">
             {isLoading ? (
               <SkeletonArray count={5} h={28} />
             ) : allComments?.length ? (
@@ -145,16 +144,7 @@ const Comments = ({ user, organizationId, feedbackId }: Props) => {
           </Grid>
         )}
 
-        {!!allComments.length && (
-          <Box
-            position="absolute"
-            bottom={0}
-            h={12}
-            w="full"
-            bgGradient="mask"
-            pointerEvents="none"
-          />
-        )}
+        {!!allComments.length && <GradientMask bottom={0} />}
       </Stack>
     </SectionContainer>
   );

--- a/src/components/feedback/Comments/Comments.tsx
+++ b/src/components/feedback/Comments/Comments.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Grid, Stack, Text, VStack } from "@omnidev/sigil";
+import { Box, Grid, Stack, Text, VStack } from "@omnidev/sigil";
 import { useMutationState } from "@tanstack/react-query";
 import { LuMessageSquare } from "react-icons/lu";
 import useInfiniteScroll from "react-infinite-scroll-hook";
@@ -96,24 +96,14 @@ const Comments = ({ user, organizationId, feedbackId }: Props) => {
       pl={{ base: 4, sm: 6 }}
       pt={{ base: 4, sm: 6 }}
     >
-      <Stack>
+      {/* NB: the margin is necessary to prevent clipping of the card borders/box shadows */}
+      <Stack position="relative" mb="1px">
         <CreateComment />
 
         {isError ? (
           <ErrorBoundary message="Error fetching comments" h="xs" my={4} />
         ) : (
-          // NB: the padding is necessary to prevent clipping of the card borders/box shadows
-          <Grid
-            gap={2}
-            mt={4}
-            maxH="sm"
-            overflow="auto"
-            p="1px"
-            scrollbar="hidden"
-            WebkitMaskImage={
-              allComments?.length ? "var(--scrollable-mask)" : undefined
-            }
-          >
+          <Grid gap={2} mt={4} maxH="sm" overflow="auto" scrollbar="hidden">
             {isLoading ? (
               <SkeletonArray count={5} h={28} />
             ) : allComments?.length ? (
@@ -153,6 +143,16 @@ const Comments = ({ user, organizationId, feedbackId }: Props) => {
               />
             )}
           </Grid>
+        )}
+
+        {!!allComments.length && (
+          <Box
+            position="absolute"
+            bottom={0}
+            h={12}
+            w="full"
+            bgGradient="mask"
+          />
         )}
       </Stack>
     </SectionContainer>

--- a/src/components/feedback/Comments/Comments.tsx
+++ b/src/components/feedback/Comments/Comments.tsx
@@ -152,6 +152,7 @@ const Comments = ({ user, organizationId, feedbackId }: Props) => {
             h={12}
             w="full"
             bgGradient="mask"
+            pointerEvents="none"
           />
         )}
       </Stack>

--- a/src/components/feedback/CreateComment/CreateComment.tsx
+++ b/src/components/feedback/CreateComment/CreateComment.tsx
@@ -49,7 +49,6 @@ const CreateComment = () => {
 
       return queryClient.invalidateQueries({
         queryKey: useInfiniteCommentsQuery.getKey({
-          pageSize: 5,
           feedbackId,
         }),
       });

--- a/src/components/feedback/FeedbackCard/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard/FeedbackCard.tsx
@@ -21,6 +21,7 @@ import {
   useStatusBreakdownQuery,
   useUpdatePostMutation,
 } from "generated/graphql";
+import { useStatusMenuStore } from "lib/hooks/store";
 
 import type { HstackProps } from "@omnidev/sigil";
 import type {
@@ -66,6 +67,13 @@ const FeedbackCard = ({
   children,
   ...rest
 }: Props) => {
+  const { isStatusMenuOpen, setIsStatusMenuOpen } = useStatusMenuStore(
+    ({ isStatusMenuOpen, setIsStatusMenuOpen }) => ({
+      isStatusMenuOpen,
+      setIsStatusMenuOpen,
+    }),
+  );
+
   const queryClient = useQueryClient();
 
   const { mutate: updateStatus, isPending: isUpdateStatusPending } =
@@ -143,6 +151,7 @@ const FeedbackCard = ({
       p={{ base: 4, sm: 6 }}
       opacity={isPending ? 0.5 : 1}
       {...rest}
+      onClick={!isStatusMenuOpen ? rest.onClick : undefined}
     >
       <Stack w="full">
         <HStack justify="space-between">
@@ -178,6 +187,10 @@ const FeedbackCard = ({
           <HStack justify="space-between">
             <HStack>
               <Menu
+                onOpenChange={({ open }) =>
+                  open ? setIsStatusMenuOpen(true) : undefined
+                }
+                onExitComplete={() => setIsStatusMenuOpen(false)}
                 trigger={
                   <StatusBadge
                     status={feedback.status!}
@@ -202,17 +215,15 @@ const FeedbackCard = ({
                       // NB: Needs to be analyzed at runtime.
                       // TODO: Implement check to validate that the status color is a valid color
                       style={status.color ? { color: status.color } : undefined}
-                      onClick={(e) => {
-                        e.stopPropagation();
-
+                      onClick={() =>
                         updateStatus({
                           rowId: feedback.rowId!,
                           patch: {
                             statusId: status.rowId!,
                             statusUpdatedAt: new Date(),
                           },
-                        });
-                      }}
+                        })
+                      }
                     >
                       {status.status}
 

--- a/src/components/feedback/FeedbackCard/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard/FeedbackCard.tsx
@@ -16,6 +16,7 @@ import { LuCheck, LuChevronDown } from "react-icons/lu";
 import { match } from "ts-pattern";
 
 import { StatusBadge } from "components/core";
+import { VotingButtons } from "components/feedback";
 import {
   useFeedbackByIdQuery,
   useInfinitePostsQuery,
@@ -49,10 +50,6 @@ interface Props extends HstackProps {
   canManageStatus: boolean;
   /** Feedback details. */
   feedback: Partial<FeedbackFragment>;
-  /** Total number of upvotes. */
-  totalUpvotes: number | undefined;
-  /** Total number of downvotes. */
-  totalDownvotes: number | undefined;
   /** Whether the feedback is pending. */
   isPending?: boolean;
   /** Project status options. */
@@ -65,11 +62,8 @@ interface Props extends HstackProps {
 const FeedbackCard = ({
   canManageStatus,
   feedback,
-  totalUpvotes = 0,
-  totalDownvotes = 0,
   isPending = false,
   projectStatuses,
-  children,
   ...rest
 }: Props) => {
   const { isStatusMenuOpen, setIsStatusMenuOpen } = useStatusMenuStore(
@@ -91,7 +85,6 @@ const FeedbackCard = ({
         ) as FeedbackByIdQuery;
 
         const postsQueryKey = useInfinitePostsQuery.getKey({
-          pageSize: 5,
           projectId: feedback.project?.rowId!,
           excludedStatuses,
           orderBy: orderBy ? (orderBy as PostOrderBy) : undefined,
@@ -168,6 +161,11 @@ const FeedbackCard = ({
         ]),
     });
 
+  const userUpvote = feedback?.userUpvotes?.nodes[0],
+    userDownvote = feedback?.userDownvotes?.nodes[0],
+    totalUpvotes = feedback?.upvotes?.totalCount ?? 0,
+    totalDownvotes = feedback?.downvotes?.totalCount ?? 0;
+
   const netTotalVotes = totalUpvotes - totalDownvotes;
 
   const netVotesColor = match(netTotalVotes)
@@ -204,7 +202,8 @@ const FeedbackCard = ({
               fontWeight="semibold"
               fontSize="lg"
               lineHeight={1}
-              maxW="50svw"
+              // TODO: figure out container queries for this. The sizing feels off across different pages on both the projects page and feedback page
+              maxW={{ base: "40svw", xl: "xl" }}
             >
               {feedback.title}
             </Text>
@@ -220,7 +219,14 @@ const FeedbackCard = ({
             </HStack>
           </Stack>
 
-          {children}
+          <VotingButtons
+            feedbackId={feedback.rowId!}
+            projectId={feedback?.project?.rowId!}
+            upvote={userUpvote}
+            downvote={userDownvote}
+            totalUpvotes={totalUpvotes}
+            totalDownvotes={totalDownvotes}
+          />
         </HStack>
 
         <Text wordBreak="break-word" color="foreground.muted">

--- a/src/components/feedback/FeedbackCard/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard/FeedbackCard.tsx
@@ -39,6 +39,8 @@ interface ProjectStatus {
 }
 
 interface Props extends HstackProps {
+  /** Whether the user has permission to manage statuses. */
+  canManageStatus: boolean;
   /** Feedback details. */
   feedback: Partial<FeedbackFragment>;
   /** Total number of upvotes. */
@@ -55,6 +57,7 @@ interface Props extends HstackProps {
  * Feedback card.
  */
 const FeedbackCard = ({
+  canManageStatus,
   feedback,
   totalUpvotes = 0,
   totalDownvotes = 0,
@@ -64,8 +67,6 @@ const FeedbackCard = ({
   ...rest
 }: Props) => {
   const queryClient = useQueryClient();
-
-  const canManageStatus = projectStatuses != null;
 
   const { mutate: updateStatus, isPending: isUpdateStatusPending } =
     useUpdatePostMutation({

--- a/src/components/feedback/FeedbackCard/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard/FeedbackCard.tsx
@@ -41,7 +41,7 @@ interface ProjectStatus {
   /** Post status. */
   status: PostStatus["status"] | undefined;
   /** Post status color. */
-  color?: PostStatus["color"];
+  color: PostStatus["color"];
 }
 
 interface Props extends HstackProps {

--- a/src/components/feedback/FeedbackCard/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard/FeedbackCard.tsx
@@ -135,10 +135,10 @@ const FeedbackCard = ({
                   if (post?.rowId === variables.rowId) {
                     return {
                       ...post,
-                      statusId: variables.patch.statusId,
                       statusUpdatedAt: variables.patch.statusUpdatedAt,
                       status: {
                         ...post?.status,
+                        rowId: variables.patch.statusId,
                         status: updatedStatus?.status,
                         color: updatedStatus?.color,
                       },

--- a/src/components/feedback/FeedbackCard/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard/FeedbackCard.tsx
@@ -247,6 +247,7 @@ const FeedbackCard = ({
                 triggerProps={{
                   disabled: !canManageStatus || isUpdateStatusPending,
                 }}
+                positioning={{ strategy: "fixed" }}
               >
                 <MenuItemGroup>
                   {projectStatuses?.map((status) => (

--- a/src/components/feedback/FeedbackDetails/FeedbackDetails.tsx
+++ b/src/components/feedback/FeedbackDetails/FeedbackDetails.tsx
@@ -16,7 +16,7 @@ import {
   useUpvoteQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
-import { useAuth, useOrganizationMembership } from "lib/hooks";
+import { useOrganizationMembership } from "lib/hooks";
 
 import type {
   HstackProps,
@@ -28,6 +28,7 @@ import {
   useHandleDownvoteMutation,
   useHandleUpvoteMutation,
 } from "lib/hooks/mutations";
+import type { Session } from "next-auth";
 import type { IconType } from "react-icons";
 
 interface VoteButtonProps extends TooltipTriggerProps {
@@ -42,6 +43,8 @@ interface VoteButtonProps extends TooltipTriggerProps {
 }
 
 interface Props extends HstackProps {
+  /** Authenticated user. */
+  user: Session["user"];
   /** Feedback ID. Used to fetch feedback details. */
   feedbackId: Post["rowId"];
 }
@@ -49,9 +52,7 @@ interface Props extends HstackProps {
 /**
  * Feedback details section.
  */
-const FeedbackDetails = ({ feedbackId, ...rest }: Props) => {
-  const { user } = useAuth();
-
+const FeedbackDetails = ({ user, feedbackId, ...rest }: Props) => {
   const { data: feedback } = useFeedbackByIdQuery(
     {
       rowId: feedbackId,

--- a/src/components/feedback/FeedbackDetails/FeedbackDetails.tsx
+++ b/src/components/feedback/FeedbackDetails/FeedbackDetails.tsx
@@ -141,10 +141,11 @@ const FeedbackDetails = ({ user, feedbackId, ...rest }: Props) => {
 
   return (
     <FeedbackCard
+      canManageStatus={isAdmin}
       feedback={feedback!}
       totalUpvotes={totalUpvotes}
       totalDownvotes={totalDownvotes}
-      projectStatuses={isAdmin ? projectStatuses : undefined}
+      projectStatuses={projectStatuses}
       boxShadow="card"
       {...rest}
     >

--- a/src/components/feedback/FeedbackDetails/FeedbackDetails.tsx
+++ b/src/components/feedback/FeedbackDetails/FeedbackDetails.tsx
@@ -1,46 +1,15 @@
 "use client";
 
-import { HStack, Icon, Tooltip } from "@omnidev/sigil";
-import {
-  PiArrowFatLineDown,
-  PiArrowFatLineDownFill,
-  PiArrowFatLineUp,
-  PiArrowFatLineUpFill,
-} from "react-icons/pi";
-
 import { FeedbackCard } from "components/feedback";
 import {
-  useDownvoteQuery,
   useFeedbackByIdQuery,
   useProjectStatusesQuery,
-  useUpvoteQuery,
 } from "generated/graphql";
-import { app } from "lib/config";
 import { useOrganizationMembership } from "lib/hooks";
 
-import type {
-  HstackProps,
-  TooltipTriggerProps,
-  VstackProps,
-} from "@omnidev/sigil";
+import type { HstackProps } from "@omnidev/sigil";
 import type { Post } from "generated/graphql";
-import {
-  useHandleDownvoteMutation,
-  useHandleUpvoteMutation,
-} from "lib/hooks/mutations";
 import type { Session } from "next-auth";
-import type { IconType } from "react-icons";
-
-interface VoteButtonProps extends TooltipTriggerProps {
-  /** Number of votes (upvotes or downvotes). */
-  votes: number | undefined;
-  /** Tooltip text. */
-  tooltip: string;
-  /** Visual icon. */
-  icon: IconType;
-  /** Props to pass to the main content container. */
-  contentProps?: VstackProps;
-}
 
 interface Props extends HstackProps {
   /** Authenticated user. */
@@ -82,104 +51,14 @@ const FeedbackDetails = ({ user, feedbackId, ...rest }: Props) => {
     },
   );
 
-  const { data: hasUpvoted } = useUpvoteQuery(
-    {
-      userId: user?.rowId!,
-      feedbackId,
-    },
-    {
-      enabled: !!user?.rowId,
-      select: (data) => data?.upvoteByPostIdAndUserId,
-    },
-  );
-
-  const { data: hasDownvoted } = useDownvoteQuery(
-    {
-      userId: user?.rowId!,
-      feedbackId,
-    },
-    {
-      enabled: !!user?.rowId,
-      select: (data) => data?.downvoteByPostIdAndUserId,
-    },
-  );
-
-  const { mutate: handleUpvote } = useHandleUpvoteMutation({
-    feedbackId,
-    upvote: hasUpvoted,
-    downvote: hasDownvoted,
-  });
-
-  const { mutate: handleDownvote } = useHandleDownvoteMutation({
-    feedbackId,
-    upvote: hasUpvoted,
-    downvote: hasDownvoted,
-  });
-
-  const totalUpvotes = feedback?.upvotes?.totalCount ?? 0;
-
-  const totalDownvotes = feedback?.downvotes?.totalCount ?? 0;
-
-  const VOTE_BUTTONS: VoteButtonProps[] = [
-    {
-      id: "upvote",
-      votes: totalUpvotes,
-      tooltip: app.feedbackPage.details.upvote,
-      icon: hasUpvoted ? PiArrowFatLineUpFill : PiArrowFatLineUp,
-      color: "brand.tertiary",
-      onClick: () => handleUpvote(),
-    },
-    {
-      id: "downvote",
-      votes: totalDownvotes,
-      tooltip: app.feedbackPage.details.downvote,
-      icon: hasDownvoted ? PiArrowFatLineDownFill : PiArrowFatLineDown,
-      color: "brand.quinary",
-      onClick: () => handleDownvote(),
-    },
-  ];
-
   return (
     <FeedbackCard
       canManageStatus={isAdmin}
       feedback={feedback!}
-      totalUpvotes={totalUpvotes}
-      totalDownvotes={totalDownvotes}
       projectStatuses={projectStatuses}
       boxShadow="card"
       {...rest}
-    >
-      <HStack
-        position="absolute"
-        top={{ base: 1.5, sm: 3.5 }}
-        right={{ base: 4, sm: 6 }}
-      >
-        {VOTE_BUTTONS.map(({ id, votes, tooltip, icon, ...rest }) => (
-          <Tooltip
-            key={id}
-            positioning={{ placement: "top" }}
-            trigger={
-              <HStack gap={2} py={1} fontVariant="tabular-nums">
-                <Icon src={icon} w={5} h={5} />
-                {votes}
-              </HStack>
-            }
-            triggerProps={{
-              variant: "icon",
-              bgColor: "transparent",
-              opacity: {
-                base: 1,
-                _disabled: 0.3,
-                _hover: { base: 0.8, _disabled: 0.3 },
-              },
-              ...rest,
-            }}
-          >
-            {tooltip}
-          </Tooltip>
-        ))}
-      </HStack>
-    </FeedbackCard>
+    />
   );
 };
 export default FeedbackDetails;

--- a/src/components/feedback/VotingButtons/VotingButtons.tsx
+++ b/src/components/feedback/VotingButtons/VotingButtons.tsx
@@ -1,0 +1,126 @@
+import { HStack, Icon, Tooltip } from "@omnidev/sigil";
+import {
+  PiArrowFatLineDown,
+  PiArrowFatLineDownFill,
+  PiArrowFatLineUp,
+  PiArrowFatLineUpFill,
+} from "react-icons/pi";
+
+import { app } from "lib/config";
+import {
+  useHandleDownvoteMutation,
+  useHandleUpvoteMutation,
+} from "lib/hooks/mutations";
+
+import type { TooltipTriggerProps, VstackProps } from "@omnidev/sigil";
+import type { Downvote, Post, Project, Upvote } from "generated/graphql";
+import type { IconType } from "react-icons";
+
+interface VoteButtonProps extends TooltipTriggerProps {
+  /** Number of votes (upvotes or downvotes). */
+  votes: number | undefined;
+  /** Tooltip text. */
+  tooltip: string;
+  /** Visual icon. */
+  icon: IconType;
+  /** Props to pass to the main content container. */
+  contentProps?: VstackProps;
+}
+
+interface Props {
+  /** Feedback ID. */
+  feedbackId: Post["rowId"];
+  /** Project ID. */
+  projectId: Project["rowId"];
+  /** Upvote object. Used to determine if the user has already upvoted */
+  upvote: Partial<Upvote> | null | undefined;
+  /** Downvote object. Used to determine if the user has already downvoted */
+  downvote: Partial<Downvote> | null | undefined;
+  /** Total number of upvotes. */
+  totalUpvotes: number;
+  /** Total number of downvotes. */
+  totalDownvotes: number;
+}
+
+const VotingButtons = ({
+  feedbackId,
+  projectId,
+  upvote,
+  downvote,
+  totalUpvotes,
+  totalDownvotes,
+}: Props) => {
+  const { mutate: handleUpvote } = useHandleUpvoteMutation({
+    feedbackId,
+    projectId,
+    upvote,
+    downvote,
+  });
+
+  const { mutate: handleDownvote } = useHandleDownvoteMutation({
+    feedbackId,
+    projectId,
+    upvote,
+    downvote,
+  });
+
+  const VOTE_BUTTONS: VoteButtonProps[] = [
+    {
+      id: "upvote",
+      votes: totalUpvotes,
+      tooltip: app.feedbackPage.details.upvote,
+      icon: upvote ? PiArrowFatLineUpFill : PiArrowFatLineUp,
+      color: "brand.tertiary",
+      onClick: (e) => {
+        e.stopPropagation();
+        handleUpvote();
+      },
+    },
+    {
+      id: "downvote",
+      votes: totalDownvotes,
+      tooltip: app.feedbackPage.details.downvote,
+      icon: downvote ? PiArrowFatLineDownFill : PiArrowFatLineDown,
+      color: "brand.quinary",
+      onClick: (e) => {
+        e.stopPropagation();
+        handleDownvote();
+      },
+    },
+  ];
+
+  return (
+    <HStack
+      position="absolute"
+      top={{ base: 1.5, sm: 3.5 }}
+      right={{ base: 4, sm: 6 }}
+    >
+      {VOTE_BUTTONS.map(({ id, votes, tooltip, icon, ...rest }) => (
+        <Tooltip
+          key={id}
+          hasArrow={false}
+          trigger={
+            <HStack gap={2} py={1} fontVariant="tabular-nums">
+              <Icon src={icon} w={5} h={5} />
+              {votes}
+            </HStack>
+          }
+          triggerProps={{
+            variant: "icon",
+            bgColor: "transparent",
+            opacity: {
+              base: 1,
+              _disabled: 0.3,
+              _hover: { base: 0.8, _disabled: 0.3 },
+            },
+            ...rest,
+          }}
+        >
+          {tooltip}
+        </Tooltip>
+      ))}
+    </HStack>
+  );
+};
+
+export default VotingButtons;

--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -4,3 +4,4 @@ export { default as CreateComment } from "./CreateComment/CreateComment";
 export { default as CreateFeedback } from "./CreateFeedback/CreateFeedback";
 export { default as FeedbackCard } from "./FeedbackCard/FeedbackCard";
 export { default as FeedbackDetails } from "./FeedbackDetails/FeedbackDetails";
+export { default as VotingButtons } from "./VotingButtons/VotingButtons";

--- a/src/components/organization/Invitations/Invitations.tsx
+++ b/src/components/organization/Invitations/Invitations.tsx
@@ -85,9 +85,10 @@ const Invitations = ({ organizationId }: Props) => {
               display: isOwner ? "flex" : "none",
             }}
             disabled={!isOwner}
-            // @ts-ignore TODO: Update Sigil component to support icon toggling in checkbox
+            // @ts-ignore TODO: Update Sigil component to remove required `src` prop
             iconProps={{
               style: {
+                // TODO: Update Sigil component to support icon toggling in checkbox
                 pointerEvents: "none",
               },
             }}
@@ -116,9 +117,10 @@ const Invitations = ({ organizationId }: Props) => {
               display: isOwner ? "flex" : "none",
             }}
             disabled={!isOwner}
-            // @ts-ignore TODO: Update Sigil component to support icon toggling in checkbox
+            // @ts-ignore TODO: Update Sigil component to remove required `src` prop
             iconProps={{
               style: {
+                // TODO: Update Sigil component to support icon toggling in checkbox
                 pointerEvents: "none",
               },
             }}

--- a/src/components/organization/Members/Members.tsx
+++ b/src/components/organization/Members/Members.tsx
@@ -93,9 +93,10 @@ const Members = ({ organizationId }: Props) => {
               display: isOwner ? "flex" : "none",
             }}
             disabled={!isOwner}
-            // @ts-ignore TODO: Update Sigil component to support icon toggling in checkbox
+            // @ts-ignore TODO: Update Sigil component to remove required `src` prop
             iconProps={{
               style: {
+                // TODO: Update Sigil component to support icon toggling in checkbox
                 pointerEvents: "none",
               },
             }}
@@ -130,9 +131,10 @@ const Members = ({ organizationId }: Props) => {
             controlProps={{
               display: isOwner ? "flex" : "none",
             }}
-            // @ts-ignore TODO: Update Sigil component to support icon toggling in checkbox
+            // @ts-ignore TODO: Update Sigil component to remove required `src` prop
             iconProps={{
               style: {
+                // TODO: Update Sigil component to support icon toggling in checkbox
                 pointerEvents: "none",
               },
             }}

--- a/src/components/profile/OrganizationInvites/OrganizationInvites.tsx
+++ b/src/components/profile/OrganizationInvites/OrganizationInvites.tsx
@@ -71,9 +71,10 @@ const OrganizationInvites = ({ email }: Props) => {
                 app.profileInvitationsPage.table.headers.organizationName
               )
             }
-            // @ts-ignore TODO: Update Sigil component to support icon toggling in checkbox
+            // @ts-ignore TODO: Update Sigil component to remove required `src` prop
             iconProps={{
               style: {
+                // TODO: Update Sigil component to support icon toggling in checkbox
                 pointerEvents: "none",
               },
             }}
@@ -98,9 +99,10 @@ const OrganizationInvites = ({ email }: Props) => {
               // NB: naturally, clicking the label will toggle the checkbox. In this case, we only want the toggle to happen when the control is clicked.
               onClick: (e) => e.preventDefault(),
             }}
-            // @ts-ignore TODO: Update Sigil component to support icon toggling in checkbox
+            // @ts-ignore TODO: Update Sigil component to remove required `src` prop
             iconProps={{
               style: {
+                // TODO: Update Sigil component to support icon toggling in checkbox
                 pointerEvents: "none",
               },
             }}

--- a/src/components/project/ProjectFeedback/ProjectFeedback.tsx
+++ b/src/components/project/ProjectFeedback/ProjectFeedback.tsx
@@ -2,6 +2,7 @@
 
 import { createListCollection } from "@ark-ui/react";
 import {
+  Box,
   Button,
   Grid,
   Icon,
@@ -200,7 +201,8 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
       pl={{ base: 4, sm: 6 }}
       pt={{ base: 4, sm: 6 }}
     >
-      <Stack gap={0}>
+      {/* NB: the margin is necessary to prevent clipping of the card borders/box shadows */}
+      <Stack gap={0} position="relative" mb="1px">
         <CreateFeedback />
 
         <Stack mt={4} direction={{ base: "column", sm: "row" }}>
@@ -234,17 +236,7 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
         {isError ? (
           <ErrorBoundary message="Error fetching feedback" h="sm" my={4} />
         ) : (
-          <Grid
-            gap={2}
-            mt={4}
-            maxH="md"
-            overflow="auto"
-            p="1px"
-            scrollbar="hidden"
-            WebkitMaskImage={
-              allPosts.length ? "var(--scrollable-mask)" : undefined
-            }
-          >
+          <Grid gap={2} mt={4} maxH="md" overflow="auto" scrollbar="hidden">
             {isLoading ? (
               <SkeletonArray count={5} h={21} />
             ) : allPosts.length ? (
@@ -308,6 +300,16 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
               />
             )}
           </Grid>
+        )}
+
+        {!!allPosts.length && (
+          <Box
+            position="absolute"
+            bottom={0}
+            h={12}
+            w="full"
+            bgGradient="mask"
+          />
         )}
       </Stack>
     </SectionContainer>

--- a/src/components/project/ProjectFeedback/ProjectFeedback.tsx
+++ b/src/components/project/ProjectFeedback/ProjectFeedback.tsx
@@ -125,9 +125,6 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
           rowId: input.post.projectId,
           name: "pending",
           slug: "pending",
-          postStatuses: {
-            nodes: [],
-          },
         },
         user: {
           username: user?.username,
@@ -150,6 +147,21 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
     userId: user.rowId,
     organizationId: posts?.[0]?.project?.organization?.rowId,
   });
+
+  const { data: projectStatuses } = useProjectStatusesQuery(
+    {
+      projectId,
+    },
+    {
+      enabled: isAdmin,
+      select: (data) =>
+        data?.postStatuses?.nodes.map((status) => ({
+          rowId: status?.rowId,
+          status: status?.status,
+          color: status?.color,
+        })),
+    },
+  );
 
   // NB: we condition displaying the pending feedback to limit jumpy behavior with optimistic updates. Dependent on the filters provided for the posts query.
   const showPendingFeedback =
@@ -239,11 +251,6 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
               <VStack>
                 {allPosts.map((feedback) => {
                   const isPending = feedback?.rowId === "pending";
-
-                  const projectStatuses =
-                    feedback?.project?.postStatuses?.nodes?.filter(
-                      (status) => status != null,
-                    );
 
                   return (
                     <FeedbackCard

--- a/src/components/project/ProjectFeedback/ProjectFeedback.tsx
+++ b/src/components/project/ProjectFeedback/ProjectFeedback.tsx
@@ -1,24 +1,13 @@
 "use client";
 
 import { createListCollection } from "@ark-ui/react";
-import {
-  Box,
-  Button,
-  Grid,
-  Icon,
-  Input,
-  Select,
-  Stack,
-  Text,
-  VStack,
-} from "@omnidev/sigil";
+import { Grid, Input, Select, Stack, Text, VStack } from "@omnidev/sigil";
 import { keepPreviousData, useMutationState } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
-import { FiArrowUpRight } from "react-icons/fi";
 import { HiOutlineFolder } from "react-icons/hi2";
 import useInfiniteScroll from "react-infinite-scroll-hook";
 
-import { SkeletonArray, Spinner } from "components/core";
+import { GradientMask, SkeletonArray, Spinner } from "components/core";
 import { CreateFeedback, FeedbackCard } from "components/feedback";
 import { EmptyState, ErrorBoundary, SectionContainer } from "components/layout";
 import {
@@ -90,7 +79,6 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
   const { data, isLoading, isError, hasNextPage, fetchNextPage } =
     useInfinitePostsQuery(
       {
-        pageSize: 5,
         projectId,
         excludedStatuses,
         orderBy: orderBy
@@ -133,8 +121,14 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
         upvotes: {
           totalCount: 0,
         },
+        userUpvotes: {
+          nodes: [],
+        },
         downvotes: {
           totalCount: 0,
+        },
+        userDownvotes: {
+          nodes: [],
         },
       };
     },
@@ -236,7 +230,15 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
         {isError ? (
           <ErrorBoundary message="Error fetching feedback" h="sm" my={4} />
         ) : (
-          <Grid gap={2} mt={4} maxH="md" overflow="auto" scrollbar="hidden">
+          <Grid
+            gap={2}
+            mt={4}
+            maxH="md"
+            overflow="auto"
+            scrollbar="hidden"
+            // NB: the padding is necessary to prevent clipping of the card borders/box shadows
+            p="1px"
+          >
             {isLoading ? (
               <SkeletonArray count={5} h={21} />
             ) : allPosts.length ? (
@@ -249,8 +251,6 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
                       key={feedback?.rowId}
                       canManageStatus={isAdmin}
                       feedback={feedback!}
-                      totalUpvotes={feedback?.upvotes?.totalCount}
-                      totalDownvotes={feedback?.downvotes?.totalCount}
                       projectStatuses={projectStatuses}
                       isPending={isPending}
                       w="full"
@@ -258,7 +258,7 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
                       borderRadius="md"
                       bgColor="card-item"
                       cursor={isPending ? "not-allowed" : "pointer"}
-                      role="group"
+                      _hover={{ boxShadow: "card" }}
                       onClick={() =>
                         !isPending
                           ? router.push(
@@ -266,22 +266,7 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
                             )
                           : undefined
                       }
-                    >
-                      <Button
-                        position="absolute"
-                        top={1}
-                        right={1}
-                        p={2}
-                        variant="icon"
-                        color={{
-                          base: "foreground.muted",
-                          _groupHover: "brand.primary",
-                        }}
-                        bgColor="transparent"
-                      >
-                        <Icon src={FiArrowUpRight} w={5} h={5} />
-                      </Button>
-                    </FeedbackCard>
+                    />
                   );
                 })}
 
@@ -302,16 +287,7 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
           </Grid>
         )}
 
-        {!!allPosts.length && (
-          <Box
-            position="absolute"
-            bottom={0}
-            h={12}
-            w="full"
-            bgGradient="mask"
-            pointerEvents="none"
-          />
-        )}
+        {!!allPosts.length && <GradientMask bottom={0} />}
       </Stack>
     </SectionContainer>
   );

--- a/src/components/project/ProjectFeedback/ProjectFeedback.tsx
+++ b/src/components/project/ProjectFeedback/ProjectFeedback.tsx
@@ -309,6 +309,7 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
             h={12}
             w="full"
             bgGradient="mask"
+            pointerEvents="none"
           />
         )}
       </Stack>

--- a/src/components/project/ProjectFeedback/ProjectFeedback.tsx
+++ b/src/components/project/ProjectFeedback/ProjectFeedback.tsx
@@ -240,17 +240,15 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
                 {allPosts.map((feedback) => {
                   const isPending = feedback?.rowId === "pending";
 
-                  // TODO: discuss below. The current condition probably could be managed better.
-                  // NB: `canManageStatus` check in `FeedbackCard` is conditionalized on `projectStatuses`. We must validate that a user has admin privileges to allow managing statuses
-                  const projectStatuses = isAdmin
-                    ? feedback?.project?.postStatuses?.nodes?.filter(
-                        (status) => status != null,
-                      )
-                    : undefined;
+                  const projectStatuses =
+                    feedback?.project?.postStatuses?.nodes?.filter(
+                      (status) => status != null,
+                    );
 
                   return (
                     <FeedbackCard
                       key={feedback?.rowId}
+                      canManageStatus={isAdmin}
                       feedback={feedback!}
                       totalUpvotes={feedback?.upvotes?.totalCount}
                       totalDownvotes={feedback?.downvotes?.totalCount}

--- a/src/components/project/ProjectOverview/ProjectOverview.tsx
+++ b/src/components/project/ProjectOverview/ProjectOverview.tsx
@@ -12,13 +12,16 @@ import {
 import { useProjectMetricsQuery } from "generated/graphql";
 
 import type { Project } from "generated/graphql";
+import type { Session } from "next-auth";
 
 interface Props {
+  /** Authenticated user. */
+  user: Session["user"];
   /** Project ID. */
   projectId: Project["rowId"];
 }
 
-const ProjectOverview = ({ projectId }: Props) => {
+const ProjectOverview = ({ user, projectId }: Props) => {
   // TODO: look into optimistic updates. Unnecessary for now, but would be nice for synchronous feedback with the details component. See: https://github.com/omnidotdev/backfeed-app/pull/58#issuecomment-2593070248 for more context.
   const { data, isLoading, isError } = useProjectMetricsQuery(
     {
@@ -40,7 +43,7 @@ const ProjectOverview = ({ projectId }: Props) => {
   return (
     <Grid columns={{ lg: 3 }} gap={6}>
       <GridItem colSpan={{ lg: 2 }}>
-        <ProjectFeedback projectId={projectId} />
+        <ProjectFeedback user={user} projectId={projectId} />
       </GridItem>
 
       <GridItem>

--- a/src/components/project/StatusBreakdown/StatusBreakdown.tsx
+++ b/src/components/project/StatusBreakdown/StatusBreakdown.tsx
@@ -88,10 +88,13 @@ const StatusBreakdown = ({ projectId }: Props) => {
                     });
               }}
               size="sm"
-              // @ts-ignore TODO: Update Sigil component to support icon toggling in checkbox
+              // @ts-ignore TODO: Update Sigil component to remove required `src` prop
               iconProps={{
                 style: {
+                  // TODO: Update Sigil component to support icon toggling in checkbox
                   pointerEvents: "none",
+                  height: 12,
+                  width: 12,
                 },
               }}
             />

--- a/src/generated/graphql.mock.ts
+++ b/src/generated/graphql.mock.ts
@@ -560,7 +560,7 @@ export const mockCreateUserMutation = (resolver: GraphQLResponseResolver<Types.C
  * @example
  * mockCommentsQuery(
  *   ({ query, variables }) => {
- *     const { pageSize, after, feedbackId } = variables;
+ *     const { feedbackId, pageSize, after } = variables;
  *     return HttpResponse.json({
  *       data: { comments }
  *     })
@@ -602,31 +602,9 @@ export const mockDashboardAggregatesQuery = (resolver: GraphQLResponseResolver<T
  * @param options Options object to customize the behavior of the mock. ([see more](https://mswjs.io/docs/api/graphql#handler-options))
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
- * mockDownvoteQuery(
- *   ({ query, variables }) => {
- *     const { userId, feedbackId } = variables;
- *     return HttpResponse.json({
- *       data: { downvoteByPostIdAndUserId }
- *     })
- *   },
- *   requestOptions
- * )
- */
-export const mockDownvoteQuery = (resolver: GraphQLResponseResolver<Types.DownvoteQuery, Types.DownvoteQueryVariables>, options?: RequestHandlerOptions) =>
-  graphql.query<Types.DownvoteQuery, Types.DownvoteQueryVariables>(
-    'Downvote',
-    resolver,
-    options
-  )
-
-/**
- * @param resolver A function that accepts [resolver arguments](https://mswjs.io/docs/api/graphql#resolver-argument) and must always return the instruction on what to do with the intercepted request. ([see more](https://mswjs.io/docs/concepts/response-resolver#resolver-instructions))
- * @param options Options object to customize the behavior of the mock. ([see more](https://mswjs.io/docs/api/graphql#handler-options))
- * @see https://mswjs.io/docs/basics/response-resolver
- * @example
  * mockFeedbackByIdQuery(
  *   ({ query, variables }) => {
- *     const { rowId } = variables;
+ *     const { rowId, userId } = variables;
  *     return HttpResponse.json({
  *       data: { post }
  *     })
@@ -780,7 +758,7 @@ export const mockOrganizationsQuery = (resolver: GraphQLResponseResolver<Types.O
  * @example
  * mockPostsQuery(
  *   ({ query, variables }) => {
- *     const { projectId, after, pageSize, orderBy, excludedStatuses, search } = variables;
+ *     const { projectId, after, pageSize, orderBy, excludedStatuses, search, userId } = variables;
  *     return HttpResponse.json({
  *       data: { posts }
  *     })
@@ -945,28 +923,6 @@ export const mockRecentFeedbackQuery = (resolver: GraphQLResponseResolver<Types.
 export const mockStatusBreakdownQuery = (resolver: GraphQLResponseResolver<Types.StatusBreakdownQuery, Types.StatusBreakdownQueryVariables>, options?: RequestHandlerOptions) =>
   graphql.query<Types.StatusBreakdownQuery, Types.StatusBreakdownQueryVariables>(
     'StatusBreakdown',
-    resolver,
-    options
-  )
-
-/**
- * @param resolver A function that accepts [resolver arguments](https://mswjs.io/docs/api/graphql#resolver-argument) and must always return the instruction on what to do with the intercepted request. ([see more](https://mswjs.io/docs/concepts/response-resolver#resolver-instructions))
- * @param options Options object to customize the behavior of the mock. ([see more](https://mswjs.io/docs/api/graphql#handler-options))
- * @see https://mswjs.io/docs/basics/response-resolver
- * @example
- * mockUpvoteQuery(
- *   ({ query, variables }) => {
- *     const { userId, feedbackId } = variables;
- *     return HttpResponse.json({
- *       data: { upvoteByPostIdAndUserId }
- *     })
- *   },
- *   requestOptions
- * )
- */
-export const mockUpvoteQuery = (resolver: GraphQLResponseResolver<Types.UpvoteQuery, Types.UpvoteQueryVariables>, options?: RequestHandlerOptions) =>
-  graphql.query<Types.UpvoteQuery, Types.UpvoteQueryVariables>(
-    'Upvote',
     resolver,
     options
   )

--- a/src/generated/graphql.sdk.ts
+++ b/src/generated/graphql.sdk.ts
@@ -4918,7 +4918,7 @@ export type UserToManyUpvoteFilter = {
 
 export type CommentFragment = { __typename?: 'Comment', rowId: string, message?: string | null, createdAt?: Date | null, user?: { __typename?: 'User', rowId: string, username?: string | null } | null };
 
-export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
+export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
 
 export type InvitationFragment = { __typename?: 'Invitation', rowId: string, email: string, organizationId: string, createdAt?: Date | null, updatedAt?: Date | null, organization?: { __typename?: 'Organization', name: string } | null };
 
@@ -5139,7 +5139,7 @@ export type FeedbackByIdQueryVariables = Exact<{
 }>;
 
 
-export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
+export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
 
 export type InvitationsQueryVariables = Exact<{
   email?: InputMaybe<Scalars['String']['input']>;
@@ -5206,7 +5206,7 @@ export type PostsQueryVariables = Exact<{
 }>;
 
 
-export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
+export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
 
 export type ProjectQueryVariables = Exact<{
   projectSlug: Scalars['String']['input'];
@@ -5321,6 +5321,13 @@ export const FeedbackFragmentDoc = gql`
       rowId
       name
       slug
+    }
+    postStatuses {
+      nodes {
+        rowId
+        status
+        color
+      }
     }
   }
   status {

--- a/src/generated/graphql.sdk.ts
+++ b/src/generated/graphql.sdk.ts
@@ -4918,7 +4918,7 @@ export type UserToManyUpvoteFilter = {
 
 export type CommentFragment = { __typename?: 'Comment', rowId: string, message?: string | null, createdAt?: Date | null, user?: { __typename?: 'User', rowId: string, username?: string | null } | null };
 
-export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
+export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
 
 export type InvitationFragment = { __typename?: 'Invitation', rowId: string, email: string, organizationId: string, createdAt?: Date | null, updatedAt?: Date | null, organization?: { __typename?: 'Organization', name: string } | null };
 
@@ -5139,7 +5139,7 @@ export type FeedbackByIdQueryVariables = Exact<{
 }>;
 
 
-export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
+export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
 
 export type InvitationsQueryVariables = Exact<{
   email?: InputMaybe<Scalars['String']['input']>;
@@ -5206,7 +5206,7 @@ export type PostsQueryVariables = Exact<{
 }>;
 
 
-export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
+export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
 
 export type ProjectQueryVariables = Exact<{
   projectSlug: Scalars['String']['input'];
@@ -5321,13 +5321,6 @@ export const FeedbackFragmentDoc = gql`
       rowId
       name
       slug
-    }
-    postStatuses {
-      nodes {
-        rowId
-        status
-        color
-      }
     }
   }
   status {

--- a/src/generated/graphql.sdk.ts
+++ b/src/generated/graphql.sdk.ts
@@ -4918,7 +4918,7 @@ export type UserToManyUpvoteFilter = {
 
 export type CommentFragment = { __typename?: 'Comment', rowId: string, message?: string | null, createdAt?: Date | null, user?: { __typename?: 'User', rowId: string, username?: string | null } | null };
 
-export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
+export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, userUpvotes: { __typename?: 'UpvoteConnection', nodes: Array<{ __typename?: 'Upvote', rowId: string } | null> }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number }, userDownvotes: { __typename?: 'DownvoteConnection', nodes: Array<{ __typename?: 'Downvote', rowId: string } | null> } };
 
 export type InvitationFragment = { __typename?: 'Invitation', rowId: string, email: string, organizationId: string, createdAt?: Date | null, updatedAt?: Date | null, organization?: { __typename?: 'Organization', name: string } | null };
 
@@ -5111,9 +5111,9 @@ export type CreateUserMutationVariables = Exact<{
 export type CreateUserMutation = { __typename?: 'Mutation', createUser?: { __typename?: 'CreateUserPayload', user?: { __typename?: 'User', rowId: string } | null } | null };
 
 export type CommentsQueryVariables = Exact<{
-  pageSize: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['Cursor']['input']>;
   feedbackId: Scalars['UUID']['input'];
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['Cursor']['input']>;
 }>;
 
 
@@ -5126,20 +5126,13 @@ export type DashboardAggregatesQueryVariables = Exact<{
 
 export type DashboardAggregatesQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number } | null, users?: { __typename?: 'UserConnection', totalCount: number } | null };
 
-export type DownvoteQueryVariables = Exact<{
-  userId: Scalars['UUID']['input'];
-  feedbackId: Scalars['UUID']['input'];
-}>;
-
-
-export type DownvoteQuery = { __typename?: 'Query', downvoteByPostIdAndUserId?: { __typename?: 'Downvote', rowId: string } | null };
-
 export type FeedbackByIdQueryVariables = Exact<{
   rowId: Scalars['UUID']['input'];
+  userId?: InputMaybe<Scalars['UUID']['input']>;
 }>;
 
 
-export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
+export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, userUpvotes: { __typename?: 'UpvoteConnection', nodes: Array<{ __typename?: 'Upvote', rowId: string } | null> }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number }, userDownvotes: { __typename?: 'DownvoteConnection', nodes: Array<{ __typename?: 'Downvote', rowId: string } | null> } } | null };
 
 export type InvitationsQueryVariables = Exact<{
   email?: InputMaybe<Scalars['String']['input']>;
@@ -5203,10 +5196,11 @@ export type PostsQueryVariables = Exact<{
   orderBy?: InputMaybe<Array<PostOrderBy> | PostOrderBy>;
   excludedStatuses?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
   search?: InputMaybe<Scalars['String']['input']>;
+  userId?: InputMaybe<Scalars['UUID']['input']>;
 }>;
 
 
-export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
+export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, userUpvotes: { __typename?: 'UpvoteConnection', nodes: Array<{ __typename?: 'Upvote', rowId: string } | null> }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number }, userDownvotes: { __typename?: 'DownvoteConnection', nodes: Array<{ __typename?: 'Downvote', rowId: string } | null> } } | null> } | null };
 
 export type ProjectQueryVariables = Exact<{
   projectSlug: Scalars['String']['input'];
@@ -5263,14 +5257,6 @@ export type StatusBreakdownQueryVariables = Exact<{
 
 
 export type StatusBreakdownQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', groupedAggregates?: Array<{ __typename?: 'PostAggregates', keys?: Array<string | null> | null, distinctCount?: { __typename?: 'PostDistinctCountAggregates', rowId?: string | null } | null }> | null } | null };
-
-export type UpvoteQueryVariables = Exact<{
-  userId: Scalars['UUID']['input'];
-  feedbackId: Scalars['UUID']['input'];
-}>;
-
-
-export type UpvoteQuery = { __typename?: 'Query', upvoteByPostIdAndUserId?: { __typename?: 'Upvote', rowId: string } | null };
 
 export type UserQueryVariables = Exact<{
   hidraId: Scalars['UUID']['input'];
@@ -5335,8 +5321,18 @@ export const FeedbackFragmentDoc = gql`
   upvotes {
     totalCount
   }
+  userUpvotes: upvotes(condition: {userId: $userId}) {
+    nodes {
+      rowId
+    }
+  }
   downvotes {
     totalCount
+  }
+  userDownvotes: downvotes(condition: {userId: $userId}) {
+    nodes {
+      rowId
+    }
   }
 }
     `;
@@ -5581,7 +5577,7 @@ export const CreateUserDocument = gql`
 }
     `;
 export const CommentsDocument = gql`
-    query Comments($pageSize: Int!, $after: Cursor, $feedbackId: UUID!) {
+    query Comments($feedbackId: UUID!, $pageSize: Int = 10, $after: Cursor) {
   comments(
     first: $pageSize
     after: $after
@@ -5615,15 +5611,8 @@ export const DashboardAggregatesDocument = gql`
   }
 }
     `;
-export const DownvoteDocument = gql`
-    query Downvote($userId: UUID!, $feedbackId: UUID!) {
-  downvoteByPostIdAndUserId(postId: $feedbackId, userId: $userId) {
-    rowId
-  }
-}
-    `;
 export const FeedbackByIdDocument = gql`
-    query FeedbackById($rowId: UUID!) {
+    query FeedbackById($rowId: UUID!, $userId: UUID) {
   post(rowId: $rowId) {
     ...Feedback
   }
@@ -5732,7 +5721,7 @@ export const OrganizationsDocument = gql`
 }
     `;
 export const PostsDocument = gql`
-    query Posts($projectId: UUID!, $after: Cursor, $pageSize: Int, $orderBy: [PostOrderBy!] = CREATED_AT_DESC, $excludedStatuses: [String!], $search: String) {
+    query Posts($projectId: UUID!, $after: Cursor, $pageSize: Int = 10, $orderBy: [PostOrderBy!] = CREATED_AT_DESC, $excludedStatuses: [String!], $search: String, $userId: UUID) {
   posts(
     after: $after
     first: $pageSize
@@ -5899,13 +5888,6 @@ export const StatusBreakdownDocument = gql`
   }
 }
     `;
-export const UpvoteDocument = gql`
-    query Upvote($userId: UUID!, $feedbackId: UUID!) {
-  upvoteByPostIdAndUserId(postId: $feedbackId, userId: $userId) {
-    rowId
-  }
-}
-    `;
 export const UserDocument = gql`
     query User($hidraId: UUID!) {
   userByHidraId(hidraId: $hidraId) {
@@ -6028,9 +6010,6 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     DashboardAggregates(variables: DashboardAggregatesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DashboardAggregatesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<DashboardAggregatesQuery>(DashboardAggregatesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'DashboardAggregates', 'query', variables);
     },
-    Downvote(variables: DownvoteQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DownvoteQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DownvoteQuery>(DownvoteDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'Downvote', 'query', variables);
-    },
     FeedbackById(variables: FeedbackByIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FeedbackByIdQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedbackByIdQuery>(FeedbackByIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'FeedbackById', 'query', variables);
     },
@@ -6075,9 +6054,6 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     StatusBreakdown(variables: StatusBreakdownQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<StatusBreakdownQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<StatusBreakdownQuery>(StatusBreakdownDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'StatusBreakdown', 'query', variables);
-    },
-    Upvote(variables: UpvoteQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpvoteQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpvoteQuery>(UpvoteDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'Upvote', 'query', variables);
     },
     User(variables: UserQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UserQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<UserQuery>(UserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'User', 'query', variables);

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -4917,7 +4917,7 @@ export type UserToManyUpvoteFilter = {
 
 export type CommentFragment = { __typename?: 'Comment', rowId: string, message?: string | null, createdAt?: Date | null, user?: { __typename?: 'User', rowId: string, username?: string | null } | null };
 
-export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
+export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
 
 export type InvitationFragment = { __typename?: 'Invitation', rowId: string, email: string, organizationId: string, createdAt?: Date | null, updatedAt?: Date | null, organization?: { __typename?: 'Organization', name: string } | null };
 
@@ -5138,7 +5138,7 @@ export type FeedbackByIdQueryVariables = Exact<{
 }>;
 
 
-export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
+export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
 
 export type InvitationsQueryVariables = Exact<{
   email?: InputMaybe<Scalars['String']['input']>;
@@ -5205,7 +5205,7 @@ export type PostsQueryVariables = Exact<{
 }>;
 
 
-export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
+export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
 
 export type ProjectQueryVariables = Exact<{
   projectSlug: Scalars['String']['input'];
@@ -5321,6 +5321,13 @@ export const FeedbackFragmentDoc = `
       rowId
       name
       slug
+    }
+    postStatuses {
+      nodes {
+        rowId
+        status
+        color
+      }
     }
   }
   status {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -4917,7 +4917,7 @@ export type UserToManyUpvoteFilter = {
 
 export type CommentFragment = { __typename?: 'Comment', rowId: string, message?: string | null, createdAt?: Date | null, user?: { __typename?: 'User', rowId: string, username?: string | null } | null };
 
-export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
+export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, userUpvotes: { __typename?: 'UpvoteConnection', nodes: Array<{ __typename?: 'Upvote', rowId: string } | null> }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number }, userDownvotes: { __typename?: 'DownvoteConnection', nodes: Array<{ __typename?: 'Downvote', rowId: string } | null> } };
 
 export type InvitationFragment = { __typename?: 'Invitation', rowId: string, email: string, organizationId: string, createdAt?: Date | null, updatedAt?: Date | null, organization?: { __typename?: 'Organization', name: string } | null };
 
@@ -5110,9 +5110,9 @@ export type CreateUserMutationVariables = Exact<{
 export type CreateUserMutation = { __typename?: 'Mutation', createUser?: { __typename?: 'CreateUserPayload', user?: { __typename?: 'User', rowId: string } | null } | null };
 
 export type CommentsQueryVariables = Exact<{
-  pageSize: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['Cursor']['input']>;
   feedbackId: Scalars['UUID']['input'];
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['Cursor']['input']>;
 }>;
 
 
@@ -5125,20 +5125,13 @@ export type DashboardAggregatesQueryVariables = Exact<{
 
 export type DashboardAggregatesQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number } | null, users?: { __typename?: 'UserConnection', totalCount: number } | null };
 
-export type DownvoteQueryVariables = Exact<{
-  userId: Scalars['UUID']['input'];
-  feedbackId: Scalars['UUID']['input'];
-}>;
-
-
-export type DownvoteQuery = { __typename?: 'Query', downvoteByPostIdAndUserId?: { __typename?: 'Downvote', rowId: string } | null };
-
 export type FeedbackByIdQueryVariables = Exact<{
   rowId: Scalars['UUID']['input'];
+  userId?: InputMaybe<Scalars['UUID']['input']>;
 }>;
 
 
-export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
+export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, userUpvotes: { __typename?: 'UpvoteConnection', nodes: Array<{ __typename?: 'Upvote', rowId: string } | null> }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number }, userDownvotes: { __typename?: 'DownvoteConnection', nodes: Array<{ __typename?: 'Downvote', rowId: string } | null> } } | null };
 
 export type InvitationsQueryVariables = Exact<{
   email?: InputMaybe<Scalars['String']['input']>;
@@ -5202,10 +5195,11 @@ export type PostsQueryVariables = Exact<{
   orderBy?: InputMaybe<Array<PostOrderBy> | PostOrderBy>;
   excludedStatuses?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
   search?: InputMaybe<Scalars['String']['input']>;
+  userId?: InputMaybe<Scalars['UUID']['input']>;
 }>;
 
 
-export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
+export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, userUpvotes: { __typename?: 'UpvoteConnection', nodes: Array<{ __typename?: 'Upvote', rowId: string } | null> }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number }, userDownvotes: { __typename?: 'DownvoteConnection', nodes: Array<{ __typename?: 'Downvote', rowId: string } | null> } } | null> } | null };
 
 export type ProjectQueryVariables = Exact<{
   projectSlug: Scalars['String']['input'];
@@ -5262,14 +5256,6 @@ export type StatusBreakdownQueryVariables = Exact<{
 
 
 export type StatusBreakdownQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', groupedAggregates?: Array<{ __typename?: 'PostAggregates', keys?: Array<string | null> | null, distinctCount?: { __typename?: 'PostDistinctCountAggregates', rowId?: string | null } | null }> | null } | null };
-
-export type UpvoteQueryVariables = Exact<{
-  userId: Scalars['UUID']['input'];
-  feedbackId: Scalars['UUID']['input'];
-}>;
-
-
-export type UpvoteQuery = { __typename?: 'Query', upvoteByPostIdAndUserId?: { __typename?: 'Upvote', rowId: string } | null };
 
 export type UserQueryVariables = Exact<{
   hidraId: Scalars['UUID']['input'];
@@ -5335,8 +5321,18 @@ export const FeedbackFragmentDoc = `
   upvotes {
     totalCount
   }
+  userUpvotes: upvotes(condition: {userId: $userId}) {
+    nodes {
+      rowId
+    }
+  }
   downvotes {
     totalCount
+  }
+  userDownvotes: downvotes(condition: {userId: $userId}) {
+    nodes {
+      rowId
+    }
   }
 }
     `;
@@ -6056,7 +6052,7 @@ useCreateUserMutation.getKey = () => ['CreateUser'];
 useCreateUserMutation.fetcher = (variables: CreateUserMutationVariables, options?: RequestInit['headers']) => graphqlFetch<CreateUserMutation, CreateUserMutationVariables>(CreateUserDocument, variables, options);
 
 export const CommentsDocument = `
-    query Comments($pageSize: Int!, $after: Cursor, $feedbackId: UUID!) {
+    query Comments($feedbackId: UUID!, $pageSize: Int = 10, $after: Cursor) {
   comments(
     first: $pageSize
     after: $after
@@ -6176,58 +6172,8 @@ useInfiniteDashboardAggregatesQuery.getKey = (variables: DashboardAggregatesQuer
 
 useDashboardAggregatesQuery.fetcher = (variables: DashboardAggregatesQueryVariables, options?: RequestInit['headers']) => graphqlFetch<DashboardAggregatesQuery, DashboardAggregatesQueryVariables>(DashboardAggregatesDocument, variables, options);
 
-export const DownvoteDocument = `
-    query Downvote($userId: UUID!, $feedbackId: UUID!) {
-  downvoteByPostIdAndUserId(postId: $feedbackId, userId: $userId) {
-    rowId
-  }
-}
-    `;
-
-export const useDownvoteQuery = <
-      TData = DownvoteQuery,
-      TError = unknown
-    >(
-      variables: DownvoteQueryVariables,
-      options?: Omit<UseQueryOptions<DownvoteQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<DownvoteQuery, TError, TData>['queryKey'] }
-    ) => {
-    
-    return useQuery<DownvoteQuery, TError, TData>(
-      {
-    queryKey: ['Downvote', variables],
-    queryFn: graphqlFetch<DownvoteQuery, DownvoteQueryVariables>(DownvoteDocument, variables),
-    ...options
-  }
-    )};
-
-useDownvoteQuery.getKey = (variables: DownvoteQueryVariables) => ['Downvote', variables];
-
-export const useInfiniteDownvoteQuery = <
-      TData = InfiniteData<DownvoteQuery>,
-      TError = unknown
-    >(
-      variables: DownvoteQueryVariables,
-      options: Omit<UseInfiniteQueryOptions<DownvoteQuery, TError, TData>, 'queryKey'> & { queryKey?: UseInfiniteQueryOptions<DownvoteQuery, TError, TData>['queryKey'] }
-    ) => {
-    
-    return useInfiniteQuery<DownvoteQuery, TError, TData>(
-      (() => {
-    const { queryKey: optionsQueryKey, ...restOptions } = options;
-    return {
-      queryKey: optionsQueryKey ?? ['Downvote.infinite', variables],
-      queryFn: (metaData) => graphqlFetch<DownvoteQuery, DownvoteQueryVariables>(DownvoteDocument, {...variables, ...(metaData.pageParam ?? {})})(),
-      ...restOptions
-    }
-  })()
-    )};
-
-useInfiniteDownvoteQuery.getKey = (variables: DownvoteQueryVariables) => ['Downvote.infinite', variables];
-
-
-useDownvoteQuery.fetcher = (variables: DownvoteQueryVariables, options?: RequestInit['headers']) => graphqlFetch<DownvoteQuery, DownvoteQueryVariables>(DownvoteDocument, variables, options);
-
 export const FeedbackByIdDocument = `
-    query FeedbackById($rowId: UUID!) {
+    query FeedbackById($rowId: UUID!, $userId: UUID) {
   post(rowId: $rowId) {
     ...Feedback
   }
@@ -6637,7 +6583,7 @@ useInfiniteOrganizationsQuery.getKey = (variables?: OrganizationsQueryVariables)
 useOrganizationsQuery.fetcher = (variables?: OrganizationsQueryVariables, options?: RequestInit['headers']) => graphqlFetch<OrganizationsQuery, OrganizationsQueryVariables>(OrganizationsDocument, variables, options);
 
 export const PostsDocument = `
-    query Posts($projectId: UUID!, $after: Cursor, $pageSize: Int, $orderBy: [PostOrderBy!] = CREATED_AT_DESC, $excludedStatuses: [String!], $search: String) {
+    query Posts($projectId: UUID!, $after: Cursor, $pageSize: Int = 10, $orderBy: [PostOrderBy!] = CREATED_AT_DESC, $excludedStatuses: [String!], $search: String, $userId: UUID) {
   posts(
     after: $after
     first: $pageSize
@@ -7147,56 +7093,6 @@ useInfiniteStatusBreakdownQuery.getKey = (variables: StatusBreakdownQueryVariabl
 
 
 useStatusBreakdownQuery.fetcher = (variables: StatusBreakdownQueryVariables, options?: RequestInit['headers']) => graphqlFetch<StatusBreakdownQuery, StatusBreakdownQueryVariables>(StatusBreakdownDocument, variables, options);
-
-export const UpvoteDocument = `
-    query Upvote($userId: UUID!, $feedbackId: UUID!) {
-  upvoteByPostIdAndUserId(postId: $feedbackId, userId: $userId) {
-    rowId
-  }
-}
-    `;
-
-export const useUpvoteQuery = <
-      TData = UpvoteQuery,
-      TError = unknown
-    >(
-      variables: UpvoteQueryVariables,
-      options?: Omit<UseQueryOptions<UpvoteQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<UpvoteQuery, TError, TData>['queryKey'] }
-    ) => {
-    
-    return useQuery<UpvoteQuery, TError, TData>(
-      {
-    queryKey: ['Upvote', variables],
-    queryFn: graphqlFetch<UpvoteQuery, UpvoteQueryVariables>(UpvoteDocument, variables),
-    ...options
-  }
-    )};
-
-useUpvoteQuery.getKey = (variables: UpvoteQueryVariables) => ['Upvote', variables];
-
-export const useInfiniteUpvoteQuery = <
-      TData = InfiniteData<UpvoteQuery>,
-      TError = unknown
-    >(
-      variables: UpvoteQueryVariables,
-      options: Omit<UseInfiniteQueryOptions<UpvoteQuery, TError, TData>, 'queryKey'> & { queryKey?: UseInfiniteQueryOptions<UpvoteQuery, TError, TData>['queryKey'] }
-    ) => {
-    
-    return useInfiniteQuery<UpvoteQuery, TError, TData>(
-      (() => {
-    const { queryKey: optionsQueryKey, ...restOptions } = options;
-    return {
-      queryKey: optionsQueryKey ?? ['Upvote.infinite', variables],
-      queryFn: (metaData) => graphqlFetch<UpvoteQuery, UpvoteQueryVariables>(UpvoteDocument, {...variables, ...(metaData.pageParam ?? {})})(),
-      ...restOptions
-    }
-  })()
-    )};
-
-useInfiniteUpvoteQuery.getKey = (variables: UpvoteQueryVariables) => ['Upvote.infinite', variables];
-
-
-useUpvoteQuery.fetcher = (variables: UpvoteQueryVariables, options?: RequestInit['headers']) => graphqlFetch<UpvoteQuery, UpvoteQueryVariables>(UpvoteDocument, variables, options);
 
 export const UserDocument = `
     query User($hidraId: UUID!) {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -4917,7 +4917,7 @@ export type UserToManyUpvoteFilter = {
 
 export type CommentFragment = { __typename?: 'Comment', rowId: string, message?: string | null, createdAt?: Date | null, user?: { __typename?: 'User', rowId: string, username?: string | null } | null };
 
-export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
+export type FeedbackFragment = { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } };
 
 export type InvitationFragment = { __typename?: 'Invitation', rowId: string, email: string, organizationId: string, createdAt?: Date | null, updatedAt?: Date | null, organization?: { __typename?: 'Organization', name: string } | null };
 
@@ -5138,7 +5138,7 @@ export type FeedbackByIdQueryVariables = Exact<{
 }>;
 
 
-export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
+export type FeedbackByIdQuery = { __typename?: 'Query', post?: { __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null };
 
 export type InvitationsQueryVariables = Exact<{
   email?: InputMaybe<Scalars['String']['input']>;
@@ -5205,7 +5205,7 @@ export type PostsQueryVariables = Exact<{
 }>;
 
 
-export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null, postStatuses: { __typename?: 'PostStatusConnection', nodes: Array<{ __typename?: 'PostStatus', rowId: string, status: string, color?: string | null } | null> } } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
+export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Post', rowId: string, title?: string | null, description?: string | null, statusUpdatedAt?: Date | null, createdAt?: Date | null, updatedAt?: Date | null, project?: { __typename?: 'Project', rowId: string, name: string, slug: string, organization?: { __typename?: 'Organization', rowId: string, name: string, slug: string } | null } | null, status?: { __typename?: 'PostStatus', rowId: string, status: string, description?: string | null, color?: string | null } | null, user?: { __typename?: 'User', username?: string | null } | null, upvotes: { __typename?: 'UpvoteConnection', totalCount: number }, downvotes: { __typename?: 'DownvoteConnection', totalCount: number } } | null> } | null };
 
 export type ProjectQueryVariables = Exact<{
   projectSlug: Scalars['String']['input'];
@@ -5321,13 +5321,6 @@ export const FeedbackFragmentDoc = `
       rowId
       name
       slug
-    }
-    postStatuses {
-      nodes {
-        rowId
-        status
-        color
-      }
     }
   }
   status {

--- a/src/lib/config/app.config.ts
+++ b/src/lib/config/app.config.ts
@@ -162,7 +162,6 @@ const app = {
       },
     },
     recentFeedback: {
-      loadMore: "Load More",
       endOf: "End of Feedback",
       emptyState: {
         message: "No recent feedback found.",

--- a/src/lib/graphql/fragments/feedback.fragment.graphql
+++ b/src/lib/graphql/fragments/feedback.fragment.graphql
@@ -14,13 +14,6 @@ fragment Feedback on Post {
       name
       slug
     }
-    postStatuses {
-      nodes {
-        rowId
-        status
-        color
-      }
-    }
   }
   status {
     rowId

--- a/src/lib/graphql/fragments/feedback.fragment.graphql
+++ b/src/lib/graphql/fragments/feedback.fragment.graphql
@@ -27,7 +27,17 @@ fragment Feedback on Post {
   upvotes {
     totalCount
   }
+  userUpvotes: upvotes(condition: { userId: $userId }) {
+    nodes {
+      rowId
+    }
+  }
   downvotes {
     totalCount
+  }
+  userDownvotes: downvotes(condition: { userId: $userId }) {
+    nodes {
+      rowId
+    }
   }
 }

--- a/src/lib/graphql/fragments/feedback.fragment.graphql
+++ b/src/lib/graphql/fragments/feedback.fragment.graphql
@@ -14,6 +14,13 @@ fragment Feedback on Post {
       name
       slug
     }
+    postStatuses {
+      nodes {
+        rowId
+        status
+        color
+      }
+    }
   }
   status {
     rowId

--- a/src/lib/graphql/queries/comments.query.graphql
+++ b/src/lib/graphql/queries/comments.query.graphql
@@ -1,4 +1,4 @@
-query Comments($pageSize: Int!, $after: Cursor, $feedbackId: UUID!) {
+query Comments($feedbackId: UUID!, $pageSize: Int = 10, $after: Cursor) {
   comments(
     first: $pageSize
     after: $after

--- a/src/lib/graphql/queries/downvote.query.graphql
+++ b/src/lib/graphql/queries/downvote.query.graphql
@@ -1,5 +1,0 @@
-query Downvote($userId: UUID!, $feedbackId: UUID!) {
-  downvoteByPostIdAndUserId(postId: $feedbackId, userId: $userId) {
-    rowId
-  }
-}

--- a/src/lib/graphql/queries/feedbackById.query.graphql
+++ b/src/lib/graphql/queries/feedbackById.query.graphql
@@ -1,4 +1,4 @@
-query FeedbackById($rowId: UUID!) {
+query FeedbackById($rowId: UUID!, $userId: UUID) {
   post(rowId: $rowId) {
     ...Feedback
   }

--- a/src/lib/graphql/queries/posts.query.graphql
+++ b/src/lib/graphql/queries/posts.query.graphql
@@ -1,10 +1,11 @@
 query Posts(
   $projectId: UUID!
   $after: Cursor
-  $pageSize: Int
+  $pageSize: Int = 10
   $orderBy: [PostOrderBy!] = CREATED_AT_DESC
   $excludedStatuses: [String!]
   $search: String
+  $userId: UUID
 ) {
   posts(
     after: $after

--- a/src/lib/graphql/queries/upvote.query.graphql
+++ b/src/lib/graphql/queries/upvote.query.graphql
@@ -1,5 +1,0 @@
-query Upvote($userId: UUID!, $feedbackId: UUID!) {
-  upvoteByPostIdAndUserId(postId: $feedbackId, userId: $userId) {
-    rowId
-  }
-}

--- a/src/lib/hooks/mutations/useHandleDownvoteMutation.tsx
+++ b/src/lib/hooks/mutations/useHandleDownvoteMutation.tsx
@@ -4,18 +4,28 @@ import {
   useCreateDownvoteMutation,
   useDeleteDownvoteMutation,
   useDeleteUpvoteMutation,
-  useDownvoteQuery,
   useFeedbackByIdQuery,
-  useUpvoteQuery,
+  useInfinitePostsQuery,
+  useProjectMetricsQuery,
 } from "generated/graphql";
-import { useAuth } from "lib/hooks";
+import { useAuth, useSearchParams } from "lib/hooks";
 
-import type { UseMutationOptions } from "@tanstack/react-query";
-import type { Downvote, FeedbackByIdQuery, Upvote } from "generated/graphql";
+import type { InfiniteData, UseMutationOptions } from "@tanstack/react-query";
+import type {
+  Downvote,
+  FeedbackByIdQuery,
+  Post,
+  PostOrderBy,
+  PostsQuery,
+  Project,
+  Upvote,
+} from "generated/graphql";
 
 interface Options {
   /** Feedback ID */
-  feedbackId: string;
+  feedbackId: Post["rowId"];
+  /** project ID */
+  projectId: Project["rowId"];
   /** Upvote object. Used to determine if the user has already upvoted */
   upvote: Partial<Upvote> | null | undefined;
   /** Downvote object. Used to determine if the user has already downvoted */
@@ -29,11 +39,14 @@ interface Options {
  */
 const useHandleDownvoteMutation = ({
   feedbackId,
+  projectId,
   upvote,
   downvote,
   mutationOptions,
 }: Options) => {
   const queryClient = useQueryClient();
+
+  const [{ excludedStatuses, orderBy, search }] = useSearchParams();
 
   const { user } = useAuth();
 
@@ -66,65 +79,96 @@ const useHandleDownvoteMutation = ({
       }
     },
     onMutate: async () => {
-      const snapshot = queryClient.getQueryData(
+      const feedbackSnapshot = queryClient.getQueryData(
         useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
       ) as FeedbackByIdQuery;
 
-      queryClient.setQueryData(
-        useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
-        {
-          post: {
-            ...snapshot?.post,
-            downvotes: {
-              ...snapshot?.post?.downvotes,
-              totalCount:
-                (snapshot?.post?.downvotes?.totalCount ?? 0) +
-                (downvote ? -1 : 1),
-            },
-            upvotes: {
-              ...snapshot?.post?.upvotes,
-              totalCount:
-                (snapshot?.post?.upvotes?.totalCount ?? 0) + (upvote ? -1 : 0),
-            },
-          },
-        },
-      );
+      const postsQueryKey = useInfinitePostsQuery.getKey({
+        projectId,
+        excludedStatuses,
+        orderBy: orderBy ? (orderBy as PostOrderBy) : undefined,
+        search,
+      });
 
-      queryClient.setQueryData(
-        useDownvoteQuery.getKey({ feedbackId, userId: user?.rowId! }),
-        downvote
-          ? null
-          : {
-              downvoteByPostIdAndUserId: {
-                rowId: "pending",
+      const postsSnapshot = queryClient.getQueryData(
+        postsQueryKey,
+      ) as InfiniteData<PostsQuery>;
+
+      if (feedbackSnapshot) {
+        queryClient.setQueryData(
+          useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
+          {
+            post: {
+              ...feedbackSnapshot?.post,
+              userDownvotes: {
+                nodes: downvote ? [] : [{ rowId: "pending" }],
+              },
+              userUpvotes: {
+                nodes: downvote ? feedbackSnapshot?.post?.userUpvotes : [],
+              },
+              downvotes: {
+                ...feedbackSnapshot?.post?.downvotes,
+                totalCount:
+                  (feedbackSnapshot?.post?.downvotes?.totalCount ?? 0) +
+                  (downvote ? -1 : 1),
+              },
+              upvotes: {
+                ...feedbackSnapshot?.post?.upvotes,
+                totalCount:
+                  (feedbackSnapshot?.post?.upvotes?.totalCount ?? 0) +
+                  (upvote ? -1 : 0),
               },
             },
-      );
-
-      if (upvote) {
-        queryClient.setQueryData(
-          useUpvoteQuery.getKey({ feedbackId, userId: user?.rowId! }),
-          null,
+          },
         );
       }
+
+      if (postsSnapshot) {
+        queryClient.setQueryData(postsQueryKey, {
+          ...postsSnapshot,
+          pages: postsSnapshot.pages.map((page) => ({
+            ...page,
+            posts: {
+              ...page.posts,
+              nodes: page.posts?.nodes?.map((post) => {
+                if (post?.rowId === feedbackId) {
+                  return {
+                    ...post,
+                    userDownvotes: {
+                      nodes: downvote ? [] : [{ rowId: "pending" }],
+                    },
+                    userUpvotes: {
+                      nodes: downvote ? post.userUpvotes : [],
+                    },
+                    upvotes: {
+                      totalCount: post.upvotes.totalCount + (upvote ? -1 : 0),
+                    },
+                    downvotes: {
+                      totalCount:
+                        post.downvotes.totalCount + (downvote ? -1 : 1),
+                    },
+                  };
+                }
+
+                return post;
+              }),
+            },
+          })),
+        });
+      }
     },
-    onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
-      });
-      queryClient.invalidateQueries({
-        queryKey: useUpvoteQuery.getKey({
-          feedbackId: feedbackId,
-          userId: user?.rowId!,
+    onSettled: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["Posts.infinite"] }),
+
+        queryClient.invalidateQueries({
+          queryKey: useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
         }),
-      });
-      queryClient.invalidateQueries({
-        queryKey: useDownvoteQuery.getKey({
-          feedbackId: feedbackId,
-          userId: user?.rowId!,
+
+        queryClient.invalidateQueries({
+          queryKey: useProjectMetricsQuery.getKey({ projectId }),
         }),
-      });
-    },
+      ]),
     ...mutationOptions,
   });
 };

--- a/src/lib/hooks/mutations/useHandleUpvoteMutation.tsx
+++ b/src/lib/hooks/mutations/useHandleUpvoteMutation.tsx
@@ -4,18 +4,28 @@ import {
   useCreateUpvoteMutation,
   useDeleteDownvoteMutation,
   useDeleteUpvoteMutation,
-  useDownvoteQuery,
   useFeedbackByIdQuery,
-  useUpvoteQuery,
+  useInfinitePostsQuery,
+  useProjectMetricsQuery,
 } from "generated/graphql";
-import { useAuth } from "lib/hooks";
+import { useAuth, useSearchParams } from "lib/hooks";
 
-import type { UseMutationOptions } from "@tanstack/react-query";
-import type { Downvote, FeedbackByIdQuery, Upvote } from "generated/graphql";
+import type { InfiniteData, UseMutationOptions } from "@tanstack/react-query";
+import type {
+  Downvote,
+  FeedbackByIdQuery,
+  Post,
+  PostOrderBy,
+  PostsQuery,
+  Project,
+  Upvote,
+} from "generated/graphql";
 
 interface Options {
   /** Feedback ID */
-  feedbackId: string;
+  feedbackId: Post["rowId"];
+  /** project ID */
+  projectId: Project["rowId"];
   /** Upvote object. Used to determine if the user has already upvoted */
   upvote: Partial<Upvote> | null | undefined;
   /** Downvote object. Used to determine if the user has already downvoted */
@@ -29,11 +39,14 @@ interface Options {
  */
 const useHandleUpvoteMutation = ({
   feedbackId,
+  projectId,
   upvote,
   downvote,
   mutationOptions,
 }: Options) => {
   const queryClient = useQueryClient();
+
+  const [{ excludedStatuses, orderBy, search }] = useSearchParams();
 
   const { user } = useAuth();
 
@@ -66,65 +79,96 @@ const useHandleUpvoteMutation = ({
       }
     },
     onMutate: async () => {
-      const snapshot = queryClient.getQueryData(
+      const feedbackSnapshot = queryClient.getQueryData(
         useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
       ) as FeedbackByIdQuery;
 
-      queryClient.setQueryData(
-        useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
-        {
-          post: {
-            ...snapshot?.post,
-            upvotes: {
-              ...snapshot?.post?.upvotes,
-              totalCount:
-                (snapshot?.post?.upvotes?.totalCount ?? 0) + (upvote ? -1 : 1),
-            },
-            downvotes: {
-              ...snapshot?.post?.downvotes,
-              totalCount:
-                (snapshot?.post?.downvotes?.totalCount ?? 0) +
-                (downvote ? -1 : 0),
-            },
-          },
-        },
-      );
+      const postsQueryKey = useInfinitePostsQuery.getKey({
+        projectId,
+        excludedStatuses,
+        orderBy: orderBy ? (orderBy as PostOrderBy) : undefined,
+        search,
+      });
 
-      queryClient.setQueryData(
-        useUpvoteQuery.getKey({ feedbackId, userId: user?.rowId! }),
-        upvote
-          ? null
-          : {
-              upvoteByPostIdAndUserId: {
-                rowId: "pending",
+      const postsSnapshot = queryClient.getQueryData(
+        postsQueryKey,
+      ) as InfiniteData<PostsQuery>;
+
+      if (feedbackSnapshot) {
+        queryClient.setQueryData(
+          useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
+          {
+            post: {
+              ...feedbackSnapshot?.post,
+              userUpvotes: {
+                nodes: upvote ? [] : [{ rowId: "pending" }],
+              },
+              userDownvotes: {
+                nodes: upvote ? feedbackSnapshot?.post?.userDownvotes : [],
+              },
+              upvotes: {
+                ...feedbackSnapshot?.post?.upvotes,
+                totalCount:
+                  (feedbackSnapshot?.post?.upvotes?.totalCount ?? 0) +
+                  (upvote ? -1 : 1),
+              },
+              downvotes: {
+                ...feedbackSnapshot?.post?.downvotes,
+                totalCount:
+                  (feedbackSnapshot?.post?.downvotes?.totalCount ?? 0) +
+                  (downvote ? -1 : 0),
               },
             },
-      );
-
-      if (downvote) {
-        queryClient.setQueryData(
-          useDownvoteQuery.getKey({ feedbackId, userId: user?.rowId! }),
-          null,
+          },
         );
       }
+
+      if (postsSnapshot) {
+        queryClient.setQueryData(postsQueryKey, {
+          ...postsSnapshot,
+          pages: postsSnapshot.pages.map((page) => ({
+            ...page,
+            posts: {
+              ...page.posts,
+              nodes: page.posts?.nodes?.map((post) => {
+                if (post?.rowId === feedbackId) {
+                  return {
+                    ...post,
+                    userUpvotes: {
+                      nodes: upvote ? [] : [{ rowId: "pending" }],
+                    },
+                    userDownvotes: {
+                      nodes: upvote ? post.userDownvotes : [],
+                    },
+                    upvotes: {
+                      totalCount: post.upvotes.totalCount + (upvote ? -1 : 1),
+                    },
+                    downvotes: {
+                      totalCount:
+                        post.downvotes.totalCount + (downvote ? -1 : 0),
+                    },
+                  };
+                }
+
+                return post;
+              }),
+            },
+          })),
+        });
+      }
     },
-    onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
-      });
-      queryClient.invalidateQueries({
-        queryKey: useUpvoteQuery.getKey({
-          feedbackId: feedbackId,
-          userId: user?.rowId!,
+    onSettled: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["Posts.infinite"] }),
+
+        queryClient.invalidateQueries({
+          queryKey: useFeedbackByIdQuery.getKey({ rowId: feedbackId }),
         }),
-      });
-      queryClient.invalidateQueries({
-        queryKey: useDownvoteQuery.getKey({
-          feedbackId: feedbackId,
-          userId: user?.rowId!,
+
+        queryClient.invalidateQueries({
+          queryKey: useProjectMetricsQuery.getKey({ projectId }),
         }),
-      });
-    },
+      ]),
     ...mutationOptions,
   });
 };

--- a/src/lib/hooks/store/index.ts
+++ b/src/lib/hooks/store/index.ts
@@ -1,1 +1,2 @@
 export { default as useDialogStore } from "./useDialogStore/useDialogStore";
+export { default as useStatusMenuStore } from "./useStatusMenuStore/useStatusMenuStore";

--- a/src/lib/hooks/store/useStatusMenuStore/useStatusMenuStore.tsx
+++ b/src/lib/hooks/store/useStatusMenuStore/useStatusMenuStore.tsx
@@ -1,0 +1,22 @@
+import { shallow } from "zustand/shallow";
+import { createWithEqualityFn } from "zustand/traditional";
+
+interface StatusMenuStore {
+  /** Whether a status menu is currently open. */
+  isStatusMenuOpen: boolean;
+  /** Handler to toggle status menu open state. */
+  setIsStatusMenuOpen: (isStatusMenuOpen: boolean) => void;
+}
+
+/**
+ * Status menu store.
+ */
+const useStatusMenuStore = createWithEqualityFn<StatusMenuStore>()(
+  (set) => ({
+    isStatusMenuOpen: false,
+    setIsStatusMenuOpen: (isStatusMenuOpen) => set({ isStatusMenuOpen }),
+  }),
+  shallow,
+);
+
+export default useStatusMenuStore;

--- a/src/lib/hooks/useSidebarNavigationItems.tsx
+++ b/src/lib/hooks/useSidebarNavigationItems.tsx
@@ -62,7 +62,7 @@ const useSidebarNavigationItems = () => {
         organizationId: organization?.rowId ?? "",
       },
       {
-        enabled: isAuthenticated && !!projectSlug,
+        enabled: isAuthenticated && !!projectSlug && !!organization,
         select: (data) => data?.projectBySlugAndOrganizationId,
       },
     );


### PR DESCRIPTION
## Description

Added functionality to allow admins to update the status for individual feedback from the project page directly. This prevents needless navigation if the admin wishes to just manage the status, and provides better UX when trying to quickly update statuses across feedback.

Additional Tasks can be found in this sub PR https://github.com/omnidotdev/backfeed-app/pull/125

## Test Steps

1) Verify that logic is sound
2) Verify that managing statuses works as expected from project page
3) Verify that if you are *not* an admin of the organization for the project you are viewing, that the manage status menu can not be accessed on either the project page or the feedback page
4) Verify that state management and event propagation works as expected
