### PR TITLE
Disabled States for Voting Buttons

### DIFF
--- a/src/components/feedback/VotingButtons/VotingButtons.tsx
+++ b/src/components/feedback/VotingButtons/VotingButtons.tsx
@@ -50,19 +50,28 @@ const VotingButtons = ({
   totalUpvotes,
   totalDownvotes,
 }: Props) => {
-  const { mutate: handleUpvote } = useHandleUpvoteMutation({
-    feedbackId,
-    projectId,
-    upvote,
-    downvote,
-  });
+  const { mutate: handleUpvote, isPending: isUpvotePending } =
+    useHandleUpvoteMutation({
+      feedbackId,
+      projectId,
+      upvote,
+      downvote,
+    });
 
-  const { mutate: handleDownvote } = useHandleDownvoteMutation({
-    feedbackId,
-    projectId,
-    upvote,
-    downvote,
-  });
+  const { mutate: handleDownvote, isPending: isDownvotePending } =
+    useHandleDownvoteMutation({
+      feedbackId,
+      projectId,
+      upvote,
+      downvote,
+    });
+
+  // NB: we set `rowId` to `pending` optimistically for these values on occasion. If an attempt at triggering a mutation happens while they are still in this state, the mutation will fail
+  const isOptimistic = [feedbackId, upvote?.rowId, downvote?.rowId].some(
+    (state) => state === "pending",
+  );
+
+  const isVotePending = isUpvotePending || isDownvotePending;
 
   const VOTE_BUTTONS: VoteButtonProps[] = [
     {
@@ -75,6 +84,7 @@ const VotingButtons = ({
         e.stopPropagation();
         handleUpvote();
       },
+      disabled: isVotePending || isOptimistic,
     },
     {
       id: "downvote",
@@ -86,6 +96,7 @@ const VotingButtons = ({
         e.stopPropagation();
         handleDownvote();
       },
+      disabled: isVotePending || isOptimistic,
     },
   ];
 
@@ -108,11 +119,6 @@ const VotingButtons = ({
           triggerProps={{
             variant: "icon",
             bgColor: "transparent",
-            opacity: {
-              base: 1,
-              _disabled: 0.3,
-              _hover: { base: 0.8, _disabled: 0.3 },
-            },
             ...rest,
           }}
         >

--- a/src/components/project/ProjectFeedback/ProjectFeedback.tsx
+++ b/src/components/project/ProjectFeedback/ProjectFeedback.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { createListCollection } from "@ark-ui/react";
-import { Grid, Input, Select, Stack, Text, VStack } from "@omnidev/sigil";
+import {
+  Divider,
+  Grid,
+  Input,
+  Select,
+  Stack,
+  Text,
+  VStack,
+} from "@omnidev/sigil";
 import { keepPreviousData, useMutationState } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import { HiOutlineFolder } from "react-icons/hi2";
@@ -198,6 +206,8 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
       {/* NB: the margin is necessary to prevent clipping of the card borders/box shadows */}
       <Stack gap={0} position="relative" mb="1px">
         <CreateFeedback />
+
+        <Divider mt={4} />
 
         <Stack mt={4} direction={{ base: "column", sm: "row" }}>
           <Input


### PR DESCRIPTION
## Description

An issue was reported that upvoting and downvoting was not always functioning properly. This PR should fix instances where a user tries to quickly toggle voting buttons (or double clicks) causing a mutation to fail due to the optimistic updates setting certain `rowId`s to `pending`.

## Test Steps

1) Validate that logic is sound
2) Verify that voting is properly disabled if a voting mutation is already inflight
3) Verify that voting is properly disabled while the button is still in an "optimistic" state
