### PR TITLE
Fix Status Filter Toggle

### DIFF
--- a/src/components/project/StatusBreakdown/StatusBreakdown.tsx
+++ b/src/components/project/StatusBreakdown/StatusBreakdown.tsx
@@ -14,12 +14,15 @@ import { DEBOUNCE_TIME } from "lib/constants";
 import { useSearchParams } from "lib/hooks";
 
 import type { CheckboxCheckedChangeDetails } from "@ark-ui/react";
-import type { Project } from "generated/graphql";
+import type { PostStatus, Project } from "generated/graphql";
 
 interface Status {
-  rowId: string | undefined;
-  status: string | undefined;
-  color: string | null | undefined;
+  /** Feedback status ID. */
+  rowId: PostStatus["rowId"];
+  /** Feedback status. */
+  status: PostStatus["status"];
+  /* Feedback status color. */
+  color: PostStatus["color"];
 }
 
 interface Props {

--- a/src/components/project/StatusBreakdown/StatusBreakdown.tsx
+++ b/src/components/project/StatusBreakdown/StatusBreakdown.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Checkbox, Flex, HStack, Text } from "@omnidev/sigil";
-import { useQueryClient } from "@tanstack/react-query";
 import { useDebounceCallback } from "usehooks-ts";
 
 import { StatusBadge } from "components/core";
@@ -32,8 +31,6 @@ interface Props {
  * Feedback status breakdown for a project.
  */
 const StatusBreakdown = ({ projectId }: Props) => {
-  const queryClient = useQueryClient();
-
   const [{ excludedStatuses }, setSearchParams] = useSearchParams();
 
   const handleToggleStatus = useDebounceCallback(
@@ -41,13 +38,6 @@ const StatusBreakdown = ({ projectId }: Props) => {
       // NB: we must filter the statuses regardless of checked status to prevent adding duplicates of the same status to the search params.
       const filteredStatuses = excludedStatuses.filter(
         (s) => s !== status?.status!,
-      );
-
-      queryClient.invalidateQueries(
-        {
-          queryKey: ["Posts.infinite"],
-        },
-        { cancelRefetch: false },
       );
 
       checked

--- a/src/components/project/StatusBreakdown/StatusBreakdown.tsx
+++ b/src/components/project/StatusBreakdown/StatusBreakdown.tsx
@@ -18,9 +18,9 @@ import type { PostStatus, Project } from "generated/graphql";
 
 interface Status {
   /** Feedback status ID. */
-  rowId: PostStatus["rowId"];
+  rowId: PostStatus["rowId"] | undefined;
   /** Feedback status. */
-  status: PostStatus["status"];
+  status: PostStatus["status"] | undefined;
   /* Feedback status color. */
   color: PostStatus["color"];
 }

--- a/src/components/project/StatusBreakdown/StatusBreakdown.tsx
+++ b/src/components/project/StatusBreakdown/StatusBreakdown.tsx
@@ -45,7 +45,8 @@ const StatusBreakdown = ({ projectId }: Props) => {
             excludedStatuses: filteredStatuses,
           })
         : setSearchParams({
-            excludedStatuses: [...filteredStatuses, status?.status!],
+            // NB: the sort method is used to stabilize the array order. This helps with query key management to avoid having multiple keys that point to the same data
+            excludedStatuses: [...filteredStatuses, status?.status!].sort(),
           });
     },
     DEBOUNCE_TIME,

--- a/src/lib/hooks/useHandleSearch.tsx
+++ b/src/lib/hooks/useHandleSearch.tsx
@@ -1,10 +1,9 @@
 import { useDebounceCallback } from "usehooks-ts";
 
+import { DEBOUNCE_TIME } from "lib/constants";
 import { useSearchParams } from "lib/hooks";
 
 import type { ChangeEvent } from "react";
-
-const DEFAULT_DELAY = 300;
 
 interface Options {
   /** Debounce delay in milliseconds. */
@@ -14,7 +13,7 @@ interface Options {
 /**
  * Custom hook for handling search input with debounce functionality. Updates search parameters based on user input.
  */
-const useHandleSearch = ({ delay = DEFAULT_DELAY }: Options = {}) => {
+const useHandleSearch = ({ delay = DEBOUNCE_TIME }: Options = {}) => {
   const [, setSearchParams] = useSearchParams();
 
   return useDebounceCallback((e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Description

There was a report that there was an issue with status filter toggling from the project page that would throw a runtime error. This PR fixes this issue by preventing duplicate statuses from being included in the `excludedStatuses` array. I also optimized how state is managed by debouncing the callback for `setSearchParams`. This prevents needless network requests if a user rapidly toggles a status (or accidentally double clicks). In addition, I removed a needless query invalidation in the handler as separate query keys are used to manage the different options the filters can provide. I also stabilized the `excludedStatuses` order to prevent having multiple query cache entries that store the same data (i.e. toggling `Planned` then `In Progress` was a separate cache entry from toggling `In Progress` then `Planned`).

## Test Steps

1) Validate that logic is sound
2) Verify that debounce logic works as expected
3) Verify that filters work as expected
4) Verify that cache entries are not needlessly duplicated with just a different in array order