### PR TITLE
Update Pattern for accessing `user`

### DIFF
--- a/src/app/organizations/[organizationSlug]/(manage)/invitations/page.tsx
+++ b/src/app/organizations/[organizationSlug]/(manage)/invitations/page.tsx
@@ -90,6 +90,7 @@ const OrganizationInvitationsPage = async ({ params }: Props) => {
 
         {/* dialogs */}
         <InviteMember
+          user={session.user}
           organizationName={organization.name!}
           organizationId={organization.rowId}
         />

--- a/src/app/organizations/[organizationSlug]/(manage)/members/page.tsx
+++ b/src/app/organizations/[organizationSlug]/(manage)/members/page.tsx
@@ -136,7 +136,7 @@ const OrganizationMembersPage = async ({ params, searchParams }: Props) => {
 
         <MembershipFilters />
 
-        <Members organizationId={organization.rowId} />
+        <Members user={session.user} organizationId={organization.rowId} />
 
         {/* dialogs */}
         {/* TODO: allow adding owners when transferring ownership is resolved. Restricting to single ownership for now. */}
@@ -145,6 +145,7 @@ const OrganizationMembersPage = async ({ params, searchParams }: Props) => {
         )}
 
         <InviteMember
+          user={session.user}
           organizationName={organization.name!}
           organizationId={organization.rowId}
         />

--- a/src/app/organizations/[organizationSlug]/(manage)/members/page.tsx
+++ b/src/app/organizations/[organizationSlug]/(manage)/members/page.tsx
@@ -6,7 +6,6 @@ import { auth } from "auth";
 import { Page } from "components/layout";
 import {
   AddOwner,
-  InviteMember,
   Members,
   MembershipFilters,
   Owners,
@@ -143,12 +142,6 @@ const OrganizationMembersPage = async ({ params, searchParams }: Props) => {
         {isOwnershipTransferEnabled && (
           <AddOwner organizationId={organization.rowId} />
         )}
-
-        <InviteMember
-          user={session.user}
-          organizationName={organization.name!}
-          organizationId={organization.rowId}
-        />
       </Page>
     </HydrationBoundary>
   );

--- a/src/app/organizations/[organizationSlug]/(manage)/settings/page.tsx
+++ b/src/app/organizations/[organizationSlug]/(manage)/settings/page.tsx
@@ -91,7 +91,7 @@ const OrganizationSettingsPage = async ({ params }: Props) => {
         pt={0}
       >
         <OrganizationSettings
-          userId={session.user.rowId!}
+          user={session.user}
           organizationId={organization.rowId}
           isOwnershipTransferEnabled={isOwnershipTransferEnabled}
         />

--- a/src/app/organizations/[organizationSlug]/projects/[projectSlug]/settings/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/[projectSlug]/settings/page.tsx
@@ -119,6 +119,7 @@ const ProjectSettingsPage = async ({ params }: Props) => {
         }}
       >
         <ProjectSettings
+          user={session.user}
           projectId={project.rowId}
           organizationSlug={organizationSlug}
           canEditStatuses={canEditStatuses}

--- a/src/app/organizations/[organizationSlug]/projects/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/page.tsx
@@ -132,7 +132,10 @@ const ProjectsPage = async ({ params, searchParams }: Props) => {
       >
         <ProjectFilters />
 
-        <ProjectList canCreateProjects={canCreateProjects} />
+        <ProjectList
+          user={session.user}
+          canCreateProjects={canCreateProjects}
+        />
 
         {/* dialogs */}
         {canCreateProjects && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,6 +99,7 @@ const HomePage = async () => {
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <DashboardPage
+        user={session.user}
         isBasicTier={isBasicTier}
         isTeamTier={isTeamTier}
         oneWeekAgo={oneWeekAgo}

--- a/src/components/dashboard/DashboardPage/DashboardPage.test.tsx
+++ b/src/components/dashboard/DashboardPage/DashboardPage.test.tsx
@@ -11,7 +11,15 @@ const oneWeekAgo = dayjs().utc().subtract(6, "days").startOf("day").toDate();
 describe("dashboard page", () => {
   beforeEach(() => {
     // TODO: add tests for different tier level renders (i.e. disabled create org button, etc)
-    render(<DashboardPage isBasicTier isTeamTier oneWeekAgo={oneWeekAgo} />);
+    render(
+      <DashboardPage
+        // TODO: mock user
+        user={{}}
+        isBasicTier
+        isTeamTier
+        oneWeekAgo={oneWeekAgo}
+      />,
+    );
   });
 
   // TODO enable below, blocked by MSW integration (see test setup file for corresponding TODO) which is further blocked by https://github.com/oven-sh/bun/issues/13072

--- a/src/components/dashboard/DashboardPage/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage/DashboardPage.tsx
@@ -20,10 +20,13 @@ import {
   useOrganizationsQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
-import { useAuth } from "lib/hooks";
 import { DialogType } from "store";
 
+import type { Session } from "next-auth";
+
 interface Props {
+  /** Authenticated user. */
+  user: Session["user"];
   /** Whether the user has basic tier subscription permissions. */
   isBasicTier: boolean;
   /** Whether the user has team tier subscription permissions. */
@@ -35,9 +38,12 @@ interface Props {
 /**
  * Dashboard page. This provides the main layout for the home page when the user is authenticated.
  */
-const DashboardPage = ({ isBasicTier, isTeamTier, oneWeekAgo }: Props) => {
-  const { user, isLoading: isAuthLoading } = useAuth();
-
+const DashboardPage = ({
+  user,
+  isBasicTier,
+  isTeamTier,
+  oneWeekAgo,
+}: Props) => {
   const {
     data: dashboardAggregates,
     isLoading,
@@ -80,8 +86,6 @@ const DashboardPage = ({ isBasicTier, isTeamTier, oneWeekAgo }: Props) => {
     },
   ];
 
-  if (isAuthLoading) return null;
-
   return (
     <Page
       header={{
@@ -108,7 +112,7 @@ const DashboardPage = ({ isBasicTier, isTeamTier, oneWeekAgo }: Props) => {
         ],
       }}
     >
-      <PinnedOrganizations isBasicTier={isBasicTier} />
+      <PinnedOrganizations user={user} isBasicTier={isBasicTier} />
 
       <Grid gap={6} alignItems="center" columns={{ base: 1, md: 2 }} w="100%">
         {aggregates.map(({ title, value, icon }) => (
@@ -124,9 +128,9 @@ const DashboardPage = ({ isBasicTier, isTeamTier, oneWeekAgo }: Props) => {
       </Grid>
 
       <Grid h="100%" w="100%" gap={6} columns={{ base: 1, md: 2 }}>
-        <FeedbackOverview oneWeekAgo={oneWeekAgo} />
+        <FeedbackOverview user={user} oneWeekAgo={oneWeekAgo} />
 
-        <RecentFeedback />
+        <RecentFeedback user={user} />
       </Grid>
     </Page>
   );

--- a/src/components/dashboard/FeedbackOverview/FeedbackOverview.tsx
+++ b/src/components/dashboard/FeedbackOverview/FeedbackOverview.tsx
@@ -16,9 +16,13 @@ import { FeedbackSection, FeedbackTooltip } from "components/dashboard";
 import { ErrorBoundary } from "components/layout";
 import { useWeeklyFeedbackQuery } from "generated/graphql";
 import { token } from "generated/panda/tokens";
-import { useAuth, useViewportSize } from "lib/hooks";
+import { useViewportSize } from "lib/hooks";
+
+import type { Session } from "next-auth";
 
 interface Props {
+  /** Authenticated user. */
+  user: Session["user"];
   /** Start of day from one week ago. */
   oneWeekAgo: Date;
 }
@@ -26,7 +30,7 @@ interface Props {
 /**
  * Feedback overview section. Displays a bar chart that displays daily feedback volume for the past 7 days.
  */
-const FeedbackOverview = ({ oneWeekAgo }: Props) => {
+const FeedbackOverview = ({ user, oneWeekAgo }: Props) => {
   const isLargeViewport = useViewportSize({
     minWidth: token("breakpoints.lg"),
   });
@@ -34,19 +38,16 @@ const FeedbackOverview = ({ oneWeekAgo }: Props) => {
   const getFormattedDate = (diff: number) =>
     dayjs(oneWeekAgo).add(diff, "day").format("ddd");
 
-  const { user } = useAuth();
-
   const {
     data: weeklyFeedback,
     isLoading,
     isError,
   } = useWeeklyFeedbackQuery(
     {
-      userId: user?.rowId!,
+      userId: user.rowId!,
       startDate: oneWeekAgo,
     },
     {
-      enabled: !!user?.rowId,
       select: (data) =>
         data?.posts?.groupedAggregates?.map((aggregate) => ({
           name: dayjs(aggregate.keys?.[0]).utc().format("ddd"),

--- a/src/components/dashboard/PinnedOrganizations/PinnedOrganizations.tsx
+++ b/src/components/dashboard/PinnedOrganizations/PinnedOrganizations.tsx
@@ -8,13 +8,15 @@ import { OrganizationCard } from "components/dashboard";
 import { EmptyState, ErrorBoundary, SectionContainer } from "components/layout";
 import { OrganizationOrderBy, useOrganizationsQuery } from "generated/graphql";
 import { app } from "lib/config";
-import { useAuth } from "lib/hooks";
 import { useDialogStore } from "lib/hooks/store";
 import { DialogType } from "store";
 
 import type { Organization } from "generated/graphql";
+import type { Session } from "next-auth";
 
 interface Props {
+  /** Authenticated user. */
+  user: Session["user"];
   /** Whether the user has basic tier subscription permissions. */
   isBasicTier: boolean;
 }
@@ -22,9 +24,7 @@ interface Props {
 /**
  * Pinned organizations section.
  */
-const PinnedOrganizations = ({ isBasicTier }: Props) => {
-  const { user } = useAuth();
-
+const PinnedOrganizations = ({ user, isBasicTier }: Props) => {
   const { setIsOpen: setIsCreateOrganizationDialogOpen } = useDialogStore({
     type: DialogType.CreateOrganization,
   });
@@ -38,11 +38,10 @@ const PinnedOrganizations = ({ isBasicTier }: Props) => {
       pageSize: 3,
       offset: 0,
       orderBy: [OrganizationOrderBy.MembersCountDesc],
-      userId: user?.rowId!,
+      userId: user.rowId!,
       isMember: true,
     },
     {
-      enabled: !!user?.rowId,
       select: (data) => data?.organizations?.nodes,
     },
   );

--- a/src/components/dashboard/RecentFeedback/RecentFeedback.tsx
+++ b/src/components/dashboard/RecentFeedback/RecentFeedback.tsx
@@ -8,20 +8,23 @@ import { FeedbackSection, Response } from "components/dashboard";
 import { EmptyState, ErrorBoundary } from "components/layout";
 import { useInfiniteRecentFeedbackQuery } from "generated/graphql";
 import { app } from "lib/config";
-import { useAuth } from "lib/hooks";
 
 import type { Post } from "generated/graphql";
+import type { Session } from "next-auth";
+
+interface Props {
+  /** Authenticated user. */
+  user: Session["user"];
+}
 
 /**
  * Recent feedback section.
  */
-const RecentFeedback = () => {
-  const { user } = useAuth();
-
+const RecentFeedback = ({ user }: Props) => {
   const { data, isLoading, isError, hasNextPage, fetchNextPage } =
     useInfiniteRecentFeedbackQuery(
       {
-        userId: user?.rowId!,
+        userId: user.rowId!,
       },
       {
         initialPageParam: undefined,

--- a/src/components/feedback/Comments/Comments.tsx
+++ b/src/components/feedback/Comments/Comments.tsx
@@ -97,7 +97,7 @@ const Comments = ({ user, organizationId, feedbackId }: Props) => {
     >
       {/* NB: the margin is necessary to prevent clipping of the card borders/box shadows */}
       <Stack position="relative" mb="1px">
-        <CreateComment />
+        <CreateComment user={user} />
 
         {isError ? (
           <ErrorBoundary message="Error fetching comments" h="xs" my={4} />

--- a/src/components/feedback/CreateComment/CreateComment.tsx
+++ b/src/components/feedback/CreateComment/CreateComment.tsx
@@ -13,8 +13,10 @@ import {
 } from "generated/graphql";
 import { app } from "lib/config";
 import { DEBOUNCE_TIME, uuidSchema } from "lib/constants";
-import { useAuth, useForm } from "lib/hooks";
+import { useForm } from "lib/hooks";
 import { toaster } from "lib/util";
+
+import type { Session } from "next-auth";
 
 const MAX_COMMENT_LENGTH = 240;
 
@@ -33,13 +35,16 @@ const createCommentSchema = z.object({
     ),
 });
 
+interface Props {
+  /** Authenticated user. */
+  user: Session["user"] | undefined;
+}
+
 /**
  * Create comment form.
  */
-const CreateComment = () => {
+const CreateComment = ({ user }: Props) => {
   const queryClient = useQueryClient();
-
-  const { user, isLoading: isAuthLoading } = useAuth();
 
   const { feedbackId } = useParams<{ feedbackId: string }>();
 
@@ -115,7 +120,7 @@ const CreateComment = () => {
             placeholder={app.feedbackPage.comments.textAreaPlaceholder}
             fontSize="sm"
             minH={16}
-            disabled={isAuthLoading}
+            disabled={!user}
             maxLength={MAX_COMMENT_LENGTH}
             errorProps={{
               top: -6,

--- a/src/components/feedback/CreateFeedback/CreateFeedback.tsx
+++ b/src/components/feedback/CreateFeedback/CreateFeedback.tsx
@@ -16,8 +16,10 @@ import {
 } from "generated/graphql";
 import { app } from "lib/config";
 import { DEBOUNCE_TIME, standardRegexSchema, uuidSchema } from "lib/constants";
-import { useAuth, useForm } from "lib/hooks";
+import { useForm } from "lib/hooks";
 import { toaster } from "lib/util";
+
+import type { Session } from "next-auth";
 
 const MAX_DESCRIPTION_LENGTH = 500;
 
@@ -41,18 +43,21 @@ const createFeedbackSchema = z.object({
     .max(MAX_DESCRIPTION_LENGTH, feedbackSchemaErrors.description.maxLength),
 });
 
+interface Props {
+  /** Authenticated user. */
+  user: Session["user"] | undefined;
+}
+
 /**
  * Create feedback form.
  */
-const CreateFeedback = () => {
+const CreateFeedback = ({ user }: Props) => {
   const queryClient = useQueryClient();
 
   const { organizationSlug, projectSlug } = useParams<{
     organizationSlug: string;
     projectSlug: string;
   }>();
-
-  const { user } = useAuth();
 
   const { data: projectId } = useProjectQuery(
     {
@@ -168,6 +173,7 @@ const CreateFeedback = () => {
             placeholder={
               app.projectPage.projectFeedback.feedbackTitle.placeholder
             }
+            disabled={!user}
           />
         )}
       </AppField>
@@ -182,6 +188,7 @@ const CreateFeedback = () => {
             rows={5}
             minH={32}
             maxLength={MAX_DESCRIPTION_LENGTH}
+            disabled={!user}
           />
         )}
       </AppField>

--- a/src/components/organization/InviteMember/InviteMember.tsx
+++ b/src/components/organization/InviteMember/InviteMember.tsx
@@ -16,13 +16,14 @@ import { token } from "generated/panda/tokens";
 import { app, isDevEnv } from "lib/config";
 import { DEBOUNCE_TIME, uuidSchema } from "lib/constants";
 import { getSdk } from "lib/graphql";
-import { useAuth, useForm, useViewportSize } from "lib/hooks";
+import { useForm, useViewportSize } from "lib/hooks";
 import { useDialogStore } from "lib/hooks/store";
 import { getQueryClient } from "lib/util";
 import { getAuthSession, toaster } from "lib/util";
 import { DialogType } from "store";
 
 import type { Organization } from "generated/graphql";
+import type { Session } from "next-auth";
 
 const MAX_NUMBER_OF_INVITES = 10;
 
@@ -106,20 +107,19 @@ const createInvitationsSchema = invitesSchema.superRefine(
 );
 
 interface Props {
+  /* Authenticated user. */
+  user: Session["user"];
   /** Organization name. */
   organizationName: Organization["name"];
   /** Organization ID. */
   organizationId: Organization["rowId"];
 }
 
-const InviteMember = ({ organizationName, organizationId }: Props) => {
-  const [numberOfToasts, setNumberOfToasts] = useState(0);
-
+const InviteMember = ({ user, organizationName, organizationId }: Props) => {
   const toastId = useRef<string>(undefined);
 
   const [isSendingInvite, setIsSendingInvite] = useState(false);
-
-  const { user } = useAuth();
+  const [numberOfToasts, setNumberOfToasts] = useState(0);
   const isSmallViewport = useViewportSize({
     minWidth: token("breakpoints.sm"),
   });
@@ -224,8 +224,8 @@ const InviteMember = ({ organizationName, organizationId }: Props) => {
         {
           email: "",
           organizationId,
-          inviterEmail: user?.email ?? "",
-          inviterUsername: user?.name ?? "",
+          inviterEmail: user.email ?? "",
+          inviterUsername: user.name ?? "",
         },
       ],
     },
@@ -345,8 +345,8 @@ const InviteMember = ({ organizationName, organizationId }: Props) => {
                     value.map((email) => ({
                       email,
                       organizationId,
-                      inviterEmail: user?.email ?? "",
-                      inviterUsername: user?.name ?? "",
+                      inviterEmail: user.email ?? "",
+                      inviterUsername: user.name ?? "",
                     })),
                   )
                 }

--- a/src/components/organization/Members/Members.tsx
+++ b/src/components/organization/Members/Members.tsx
@@ -23,14 +23,17 @@ import { match } from "ts-pattern";
 import { MembershipMenu } from "components/organization";
 import { Role, useMembersQuery } from "generated/graphql";
 import { app } from "lib/config";
-import { useAuth, useOrganizationMembership, useSearchParams } from "lib/hooks";
+import { useOrganizationMembership, useSearchParams } from "lib/hooks";
 import { capitalizeFirstLetter } from "lib/util";
 
 import type { MemberFragment, Organization } from "generated/graphql";
+import type { Session } from "next-auth";
 
 const columnHelper = createColumnHelper<MemberFragment>();
 
 interface Props {
+  /** Authenticated user. */
+  user: Session["user"] | undefined;
   /** Organization ID. */
   organizationId: Organization["rowId"];
 }
@@ -38,9 +41,7 @@ interface Props {
 /**
  * Organization members table.
  */
-const Members = ({ organizationId }: Props) => {
-  const { user } = useAuth();
-
+const Members = ({ user, organizationId }: Props) => {
   const { isOwner } = useOrganizationMembership({
     userId: user?.rowId,
     organizationId,

--- a/src/components/organization/OrganizationSettings/OrganizationSettings.tsx
+++ b/src/components/organization/OrganizationSettings/OrganizationSettings.tsx
@@ -23,7 +23,8 @@ import { useOrganizationMembership } from "lib/hooks";
 import { useTransferOwnershipMutation } from "lib/hooks/mutations";
 
 import type { DestructiveActionProps } from "components/core";
-import type { Organization, User } from "generated/graphql";
+import type { Organization } from "generated/graphql";
+import type { Session } from "next-auth";
 
 const deleteOrganizationDetails =
   app.organizationSettingsPage.cta.deleteOrganization;
@@ -33,8 +34,8 @@ const transferOwnershipDetails =
   app.organizationSettingsPage.cta.transferOwnership;
 
 interface Props {
-  /** User ID. */
-  userId: User["rowId"];
+  /** Authenticated user. */
+  user: Session["user"];
   /** Organization ID. */
   organizationId: Organization["rowId"];
   /** Whether the transfer ownership functionality is enabled. */
@@ -43,7 +44,7 @@ interface Props {
 
 /** Organization settings. */
 const OrganizationSettings = ({
-  userId,
+  user,
   organizationId,
   isOwnershipTransferEnabled,
 }: Props) => {
@@ -80,14 +81,14 @@ const OrganizationSettings = ({
   );
 
   const { isOwner, membershipId } = useOrganizationMembership({
-    userId,
+    userId: user.rowId,
     organizationId,
   });
 
   const onSettled = () =>
     queryClient.invalidateQueries({
       queryKey: useOrganizationRoleQuery.getKey({
-        userId,
+        userId: user.rowId!,
         organizationId,
       }),
     });
@@ -166,7 +167,7 @@ const OrganizationSettings = ({
 
   return (
     <Stack gap={6}>
-      <UpdateOrganization />
+      <UpdateOrganization user={user} />
 
       <SectionContainer
         title={app.organizationSettingsPage.dangerZone.title}

--- a/src/components/organization/UpdateOrganization/UpdateOrganization.tsx
+++ b/src/components/organization/UpdateOrganization/UpdateOrganization.tsx
@@ -17,8 +17,10 @@ import {
   slugSchema,
 } from "lib/constants";
 import { getSdk } from "lib/graphql";
-import { useAuth, useForm, useOrganizationMembership } from "lib/hooks";
+import { useForm, useOrganizationMembership } from "lib/hooks";
 import { generateSlug, getAuthSession } from "lib/util";
+
+import type { Session } from "next-auth";
 
 const updateOrganizationDetails =
   app.organizationSettingsPage.cta.updateOrganization;
@@ -53,16 +55,19 @@ const updateOrganizationSchema = z
     }
   });
 
+interface Props {
+  /** Authenticated user. */
+  user: Session["user"];
+}
+
 /**
  * Form for updating organization details.
  */
-const UpdateOrganization = () => {
+const UpdateOrganization = ({ user }: Props) => {
   const queryClient = useQueryClient();
   const router = useRouter();
 
   const { organizationSlug } = useParams<{ organizationSlug: string }>();
-
-  const { user } = useAuth();
 
   const { data: organization } = useOrganizationQuery(
     {
@@ -74,7 +79,7 @@ const UpdateOrganization = () => {
   );
 
   const { isAdmin } = useOrganizationMembership({
-    userId: user?.rowId,
+    userId: user.rowId,
     organizationId: organization?.rowId,
   });
 

--- a/src/components/project/ProjectFeedback/ProjectFeedback.tsx
+++ b/src/components/project/ProjectFeedback/ProjectFeedback.tsx
@@ -205,7 +205,7 @@ const ProjectFeedback = ({ user, projectId }: Props) => {
     >
       {/* NB: the margin is necessary to prevent clipping of the card borders/box shadows */}
       <Stack gap={0} position="relative" mb="1px">
-        <CreateFeedback />
+        <CreateFeedback user={user} />
 
         <Divider mt={4} />
 

--- a/src/components/project/ProjectList/ProjectList.tsx
+++ b/src/components/project/ProjectList/ProjectList.tsx
@@ -15,8 +15,11 @@ import { useDialogStore } from "lib/hooks/store";
 import { DialogType } from "store";
 
 import type { Project } from "generated/graphql";
+import type { Session } from "next-auth";
 
 interface Props {
+  /** Authenticated user. */
+  user: Session["user"] | undefined;
   /** Whether the user has necessary permissions to create projects. */
   canCreateProjects: boolean;
 }
@@ -24,7 +27,7 @@ interface Props {
 /**
  * Project list.
  */
-const ProjectList = ({ canCreateProjects }: Props) => {
+const ProjectList = ({ user, canCreateProjects }: Props) => {
   const { organizationSlug } = useParams<{ organizationSlug: string }>();
 
   const [{ page, pageSize, search }, setSearchParams] = useSearchParams();
@@ -86,7 +89,11 @@ const ProjectList = ({ canCreateProjects }: Props) => {
     <Stack align="center" justify="space-between" h="100%">
       <Stack w="100%">
         {projects.map((project) => (
-          <ProjectListItem key={project?.rowId} project={project as Project} />
+          <ProjectListItem
+            key={project?.rowId}
+            user={user}
+            project={project as Project}
+          />
         ))}
       </Stack>
 

--- a/src/components/project/ProjectListItem/ProjectListItem.tsx
+++ b/src/components/project/ProjectListItem/ProjectListItem.tsx
@@ -8,12 +8,16 @@ import {
 import { LuSettings } from "react-icons/lu";
 
 import { Link, OverflowText } from "components/core";
-import { useAuth, useOrganizationMembership } from "lib/hooks";
+import { useOrganizationMembership } from "lib/hooks";
 import { setSingularOrPlural } from "lib/util";
 
 import type { Project } from "generated/graphql";
+import type { Session } from "next-auth";
 
 interface Props {
+  /** Authenticated user. */
+  user: Session["user"] | undefined;
+  /** Project details. */
   project: Partial<Project>;
 }
 
@@ -21,10 +25,9 @@ interface Props {
  * Project list item.
  */
 const ProjectListItem = ({
+  user,
   project: { slug, organization, name, description, posts },
 }: Props) => {
-  const { user } = useAuth();
-
   const { isAdmin } = useOrganizationMembership({
     userId: user?.rowId,
     organizationId: organization?.rowId,

--- a/src/components/project/ProjectSettings/ProjectSettings.tsx
+++ b/src/components/project/ProjectSettings/ProjectSettings.tsx
@@ -13,14 +13,16 @@ import {
   useOrganizationsQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
-import { useAuth } from "lib/hooks";
 
 import type { DestructiveActionProps } from "components/core";
 import type { Organization, Project } from "generated/graphql";
+import type { Session } from "next-auth";
 
 const deleteProjectDetails = app.projectSettingsPage.cta.deleteProject;
 
 interface Props {
+  /** Authenticated user. */
+  user: Session["user"];
   /** Project ID. */
   projectId: Project["rowId"];
   /** Organization slug. */
@@ -33,12 +35,11 @@ interface Props {
  * Project settings.
  */
 const ProjectSettings = ({
+  user,
   projectId,
   organizationSlug,
   canEditStatuses,
 }: Props) => {
-  const { user } = useAuth();
-
   const router = useRouter();
 
   const queryClient = useQueryClient();
@@ -50,7 +51,7 @@ const ProjectSettings = ({
       // ! NB: needed to invalidate the number of projects for an organization in the `CreateProject` dialog
       queryClient.invalidateQueries({
         queryKey: useOrganizationsQuery.getKey({
-          userId: user?.rowId!,
+          userId: user.rowId!,
           isMember: true,
           slug: organizationSlug,
           excludeRoles: [Role.Member],


### PR DESCRIPTION
## Description

So, lets take a query that requires `user.rowId` as a variable, if we are getting that `user` from the server, then the prefetch we do for it initially works as expected. But if in the client component we get user from our custom `useAuth` hook the client isnt hydrated appropriately with the correct `user`. This is because when the query is first triggered on the client, it assumes `user` is undefined because that is what is provided by `useAuth` until the session is fetched client side. This means we end up having an extra query cache entry (although with proper settings it should be `disabled`) with a key that has `userId` being `undefined`, something like:

```
["OrganizationRole",{"organizationId":"org-id"}]
```

But what we want from the prefetch is to use this right away:

```
["OrganizationRole",{"organizationId":"org-id","userId":"user-id"}] 
```

Both cache entries are created, but we get a small window where the render will be incorrect while `user` is still being fetched for the client.

Now, there are cases where `useAuth` / fetching client side still work well! For example:

1) If being used for a query in a dialog that does not default to open. Nothing for the initial render is really "blocked" for that as long as the query can properly handle the `undefined` state with the `enabled` prop.

2) If being used in onClick handlers, for similar reasoning (i.e. `PricingCard` component).

3) When the `user` can not be drilled down from the server (i.e. layout components like `AccountInformation`).

4) Custom hooks.

This PR fixes this issue by establishing a pattern to prop drill the `user` object that we fetched from the server side `auth` call when validating the session, where applicable.

## Test Steps

1) Verify that logic is sound
2) Validate that rendering and functionality across pages works as intended
