### PR TITLE
Use `queryOptions` API

### DIFF
--- a/src/app/organizations/[organizationSlug]/projects/[projectSlug]/[feedbackId]/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/[projectSlug]/[feedbackId]/page.tsx
@@ -7,7 +7,6 @@ import { Page } from "components/layout";
 import {
   Role,
   useCommentsQuery,
-  useFeedbackByIdQuery,
   useInfiniteCommentsQuery,
   useOrganizationRoleQuery,
   useProjectStatusesQuery,
@@ -15,7 +14,7 @@ import {
 import { getFeedback } from "lib/actions";
 import { app } from "lib/config";
 import { getSdk } from "lib/graphql";
-import { freeTierCommentsOptions } from "lib/options";
+import { feedbackByIdOptions, freeTierCommentsOptions } from "lib/options";
 import { getQueryClient } from "lib/util";
 
 import type { BreadcrumbRecord } from "components/core";
@@ -86,16 +85,12 @@ const FeedbackPage = async ({ params }: Props) => {
   ];
 
   await Promise.all([
-    queryClient.prefetchQuery({
-      queryKey: useFeedbackByIdQuery.getKey({
+    queryClient.prefetchQuery(
+      feedbackByIdOptions({
         rowId: feedbackId,
         userId: session?.user.rowId,
       }),
-      queryFn: useFeedbackByIdQuery.fetcher({
-        rowId: feedbackId,
-        userId: session?.user.rowId,
-      }),
-    }),
+    ),
     queryClient.prefetchInfiniteQuery({
       queryKey: useInfiniteCommentsQuery.getKey({ feedbackId }),
       queryFn: useCommentsQuery.fetcher({ feedbackId }),

--- a/src/app/organizations/[organizationSlug]/projects/[projectSlug]/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/[projectSlug]/page.tsx
@@ -10,14 +10,17 @@ import {
   Role,
   useOrganizationRoleQuery,
   useProjectMetricsQuery,
-  useProjectQuery,
   useProjectStatusesQuery,
   useStatusBreakdownQuery,
 } from "generated/graphql";
 import { getProject } from "lib/actions";
 import { app } from "lib/config";
 import { getSdk } from "lib/graphql";
-import { freeTierFeedbackOptions, infinitePostsOptions } from "lib/options";
+import {
+  freeTierFeedbackOptions,
+  infinitePostsOptions,
+  projectOptions,
+} from "lib/options";
 import { getQueryClient, getSearchParams } from "lib/util";
 
 import type { BreadcrumbRecord } from "components/core";
@@ -93,16 +96,13 @@ const ProjectPage = async ({ params, searchParams }: Props) => {
   ];
 
   await Promise.all([
-    queryClient.prefetchQuery({
-      queryKey: useProjectQuery.getKey({
+    queryClient.prefetchQuery(
+      projectOptions({
         projectSlug,
         organizationSlug,
+        userId: session?.user.rowId,
       }),
-      queryFn: useProjectQuery.fetcher({
-        projectSlug,
-        organizationSlug,
-      }),
-    }),
+    ),
     queryClient.prefetchQuery(
       freeTierFeedbackOptions({ organizationSlug, projectSlug }),
     ),

--- a/src/app/organizations/[organizationSlug]/projects/[projectSlug]/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/[projectSlug]/page.tsx
@@ -7,11 +7,8 @@ import { auth } from "auth";
 import { Page } from "components/layout";
 import { ProjectOverview } from "components/project";
 import {
-  PostOrderBy,
   Role,
-  useInfinitePostsQuery,
   useOrganizationRoleQuery,
-  usePostsQuery,
   useProjectMetricsQuery,
   useProjectQuery,
   useProjectStatusesQuery,
@@ -20,7 +17,7 @@ import {
 import { getProject } from "lib/actions";
 import { app } from "lib/config";
 import { getSdk } from "lib/graphql";
-import { freeTierFeedbackOptions } from "lib/options";
+import { freeTierFeedbackOptions, infinitePostsOptions } from "lib/options";
 import { getQueryClient, getSearchParams } from "lib/util";
 
 import type { BreadcrumbRecord } from "components/core";
@@ -109,27 +106,15 @@ const ProjectPage = async ({ params, searchParams }: Props) => {
     queryClient.prefetchQuery(
       freeTierFeedbackOptions({ organizationSlug, projectSlug }),
     ),
-    queryClient.prefetchInfiniteQuery({
-      queryKey: useInfinitePostsQuery.getKey({
+    queryClient.prefetchInfiniteQuery(
+      infinitePostsOptions({
         projectId: project.rowId,
-        excludedStatuses,
-        orderBy: orderBy
-          ? [orderBy as PostOrderBy, PostOrderBy.CreatedAtDesc]
-          : undefined,
-        search,
         userId: session?.user.rowId,
-      }),
-      queryFn: usePostsQuery.fetcher({
-        projectId: project.rowId,
         excludedStatuses,
-        orderBy: orderBy
-          ? [orderBy as PostOrderBy, PostOrderBy.CreatedAtDesc]
-          : undefined,
+        orderBy,
         search,
-        userId: session?.user.rowId,
       }),
-      initialPageParam: undefined,
-    }),
+    ),
     ...(session
       ? [
           queryClient.prefetchQuery({

--- a/src/app/organizations/[organizationSlug]/projects/[projectSlug]/settings/page.tsx
+++ b/src/app/organizations/[organizationSlug]/projects/[projectSlug]/settings/page.tsx
@@ -4,14 +4,11 @@ import { notFound } from "next/navigation";
 import { auth } from "auth";
 import { Page } from "components/layout";
 import { ProjectSettings } from "components/project";
-import {
-  Role,
-  useProjectQuery,
-  useProjectStatusesQuery,
-} from "generated/graphql";
+import { Role, useProjectStatusesQuery } from "generated/graphql";
 import { getProject } from "lib/actions";
 import { app, isDevEnv } from "lib/config";
 import { getSdk } from "lib/graphql";
+import { projectOptions } from "lib/options";
 import { getQueryClient } from "lib/util";
 
 import type { BreadcrumbRecord } from "components/core";
@@ -86,10 +83,13 @@ const ProjectSettingsPage = async ({ params }: Props) => {
   ];
 
   await Promise.all([
-    queryClient.prefetchQuery({
-      queryKey: useProjectQuery.getKey({ projectSlug, organizationSlug }),
-      queryFn: useProjectQuery.fetcher({ projectSlug, organizationSlug }),
-    }),
+    queryClient.prefetchQuery(
+      projectOptions({
+        projectSlug,
+        organizationSlug,
+        userId: session?.user.rowId,
+      }),
+    ),
     // TODO: when ready to implement for production, remove the development environment check
     ...(isDevEnv
       ? [

--- a/src/components/feedback/CommentCard/CommentCard.tsx
+++ b/src/components/feedback/CommentCard/CommentCard.tsx
@@ -23,11 +23,11 @@ import { DestructiveAction } from "components/core";
 import { CreateReply, Replies } from "components/feedback";
 import {
   useDeleteCommentMutation,
-  useFeedbackByIdQuery,
   useInfiniteCommentsQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
 import { useOrganizationMembership } from "lib/hooks";
+import { feedbackByIdOptions } from "lib/options";
 import { setSingularOrPlural } from "lib/util";
 
 import type { StackProps } from "@omnidev/sigil";
@@ -87,12 +87,12 @@ const CommentCard = ({
             }),
           }),
           queryClient.invalidateQueries({ queryKey: ["Posts.infinite"] }),
-          queryClient.invalidateQueries({
-            queryKey: useFeedbackByIdQuery.getKey({
+          queryClient.invalidateQueries(
+            feedbackByIdOptions({
               rowId: feedbackId,
               userId: user?.rowId,
             }),
-          }),
+          ),
         ]),
     });
 

--- a/src/components/feedback/CreateComment/CreateComment.tsx
+++ b/src/components/feedback/CreateComment/CreateComment.tsx
@@ -9,13 +9,12 @@ import { z } from "zod";
 import { CharacterLimit } from "components/core";
 import {
   useCreateCommentMutation,
-  useFeedbackByIdQuery,
   useInfiniteCommentsQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
 import { DEBOUNCE_TIME, uuidSchema } from "lib/constants";
 import { useForm } from "lib/hooks";
-import { freeTierCommentsOptions } from "lib/options";
+import { feedbackByIdOptions, freeTierCommentsOptions } from "lib/options";
 import { toaster } from "lib/util";
 
 import type { Session } from "next-auth";
@@ -68,12 +67,12 @@ const CreateComment = ({ user, canCreateComment }: Props) => {
             feedbackId,
           }),
         ),
-        queryClient.invalidateQueries({
-          queryKey: useFeedbackByIdQuery.getKey({
+        queryClient.invalidateQueries(
+          feedbackByIdOptions({
             rowId: feedbackId,
             userId: user?.rowId,
           }),
-        }),
+        ),
       ]);
 
       return queryClient.invalidateQueries({

--- a/src/components/feedback/CreateFeedback/CreateFeedback.tsx
+++ b/src/components/feedback/CreateFeedback/CreateFeedback.tsx
@@ -10,14 +10,13 @@ import { CharacterLimit } from "components/core";
 import {
   useCreateFeedbackMutation,
   useProjectMetricsQuery,
-  useProjectQuery,
   useProjectStatusesQuery,
   useStatusBreakdownQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
 import { DEBOUNCE_TIME, uuidSchema } from "lib/constants";
 import { useForm } from "lib/hooks";
-import { freeTierFeedbackOptions } from "lib/options";
+import { freeTierFeedbackOptions, projectOptions } from "lib/options";
 import { toaster } from "lib/util";
 
 import type { Session } from "next-auth";
@@ -66,16 +65,15 @@ const CreateFeedback = ({ user }: Props) => {
     freeTierFeedbackOptions({ organizationSlug, projectSlug }),
   );
 
-  const { data: projectId } = useProjectQuery(
-    {
+  const { data: projectId } = useQuery({
+    ...projectOptions({
       projectSlug,
       organizationSlug,
-    },
-    {
-      enabled: !!projectSlug && !!organizationSlug,
-      select: (data) => data?.projects?.nodes?.[0]?.rowId,
-    },
-  );
+      userId: user?.rowId,
+    }),
+    enabled: !!projectSlug && !!organizationSlug,
+    select: (data) => data?.projects?.nodes?.[0]?.rowId,
+  });
 
   const { data: defaultStatusId } = useProjectStatusesQuery(
     {

--- a/src/components/feedback/CreateReply/CreateReply.tsx
+++ b/src/components/feedback/CreateReply/CreateReply.tsx
@@ -9,7 +9,6 @@ import { z } from "zod";
 import { CharacterLimit } from "components/core";
 import {
   useCreateCommentMutation,
-  useFeedbackByIdQuery,
   useInfiniteCommentsQuery,
   useInfiniteRepliesQuery,
 } from "generated/graphql";
@@ -17,7 +16,7 @@ import { token } from "generated/panda/tokens";
 import { app } from "lib/config";
 import { DEBOUNCE_TIME, uuidSchema } from "lib/constants";
 import { useAuth, useForm } from "lib/hooks";
-import { freeTierCommentsOptions } from "lib/options";
+import { feedbackByIdOptions, freeTierCommentsOptions } from "lib/options";
 import { toaster } from "lib/util";
 
 import type { CollapsibleProps } from "@omnidev/sigil";
@@ -75,12 +74,12 @@ const CreateReply = ({ commentId, canReply, onReply, ...rest }: Props) => {
             feedbackId,
           }),
         }),
-        queryClient.invalidateQueries({
-          queryKey: useFeedbackByIdQuery.getKey({
+        queryClient.invalidateQueries(
+          feedbackByIdOptions({
             rowId: feedbackId,
             userId: user?.rowId,
           }),
-        }),
+        ),
         queryClient.invalidateQueries(
           freeTierCommentsOptions({
             organizationSlug,

--- a/src/components/feedback/FeedbackCard/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard/FeedbackCard.tsx
@@ -19,7 +19,6 @@ import { DestructiveAction, StatusBadge } from "components/core";
 import { UpdateFeedback, VotingButtons } from "components/feedback";
 import {
   useDeletePostMutation,
-  useFeedbackByIdQuery,
   useProjectMetricsQuery,
   useStatusBreakdownQuery,
   useUpdatePostMutation,
@@ -37,7 +36,7 @@ import type {
   PostsQuery,
 } from "generated/graphql";
 import { app } from "lib/config";
-import { infinitePostsOptions } from "lib/options";
+import { feedbackByIdOptions, infinitePostsOptions } from "lib/options";
 
 import type { Session } from "next-auth";
 
@@ -123,11 +122,13 @@ const FeedbackCard = ({
   const { mutate: updateStatus, isPending: isUpdateStatusPending } =
     useUpdatePostMutation({
       onMutate: (variables) => {
+        const feedbackKey = feedbackByIdOptions({
+          rowId: feedback.rowId!,
+          userId: user?.rowId,
+        }).queryKey;
+
         const feedbackSnapshot = queryClient.getQueryData(
-          useFeedbackByIdQuery.getKey({
-            rowId: feedback.rowId!,
-            userId: user?.rowId,
-          }),
+          feedbackKey,
         ) as FeedbackByIdQuery;
 
         const postsQueryKey = infinitePostsOptions({
@@ -146,24 +147,18 @@ const FeedbackCard = ({
         );
 
         if (feedbackSnapshot) {
-          queryClient.setQueryData(
-            useFeedbackByIdQuery.getKey({
-              rowId: feedback.rowId!,
-              userId: user?.rowId,
-            }),
-            {
-              post: {
-                ...feedbackSnapshot.post,
-                statusId: variables.patch.statusId,
-                statusUpdatedAt: variables.patch.statusUpdatedAt,
-                status: {
-                  ...feedbackSnapshot.post?.status,
-                  status: updatedStatus?.status,
-                  color: updatedStatus?.color,
-                },
+          queryClient.setQueryData(feedbackKey, {
+            post: {
+              ...feedbackSnapshot.post,
+              statusId: variables.patch.statusId,
+              statusUpdatedAt: variables.patch.statusUpdatedAt,
+              status: {
+                ...feedbackSnapshot.post?.status,
+                status: updatedStatus?.status,
+                color: updatedStatus?.color,
               },
             },
-          );
+          } as FeedbackByIdQuery);
         }
 
         if (postsSnapshot) {
@@ -211,12 +206,12 @@ const FeedbackCard = ({
             }),
           }),
 
-          queryClient.invalidateQueries({
-            queryKey: useFeedbackByIdQuery.getKey({
+          queryClient.invalidateQueries(
+            feedbackByIdOptions({
               rowId: feedback.rowId!,
               userId: user?.rowId,
             }),
-          }),
+          ),
         ]),
     });
 

--- a/src/components/feedback/FeedbackDetails/FeedbackDetails.tsx
+++ b/src/components/feedback/FeedbackDetails/FeedbackDetails.tsx
@@ -1,11 +1,10 @@
 "use client";
+import { useQuery } from "@tanstack/react-query";
 
 import { FeedbackCard } from "components/feedback";
-import {
-  useFeedbackByIdQuery,
-  useProjectStatusesQuery,
-} from "generated/graphql";
+import { useProjectStatusesQuery } from "generated/graphql";
 import { useOrganizationMembership } from "lib/hooks";
+import { feedbackByIdOptions } from "lib/options";
 
 import type { HstackProps } from "@omnidev/sigil";
 import type { Post } from "generated/graphql";
@@ -22,14 +21,8 @@ interface Props extends HstackProps {
  * Feedback details section.
  */
 const FeedbackDetails = ({ user, feedbackId, ...rest }: Props) => {
-  const { data: feedback } = useFeedbackByIdQuery(
-    {
-      rowId: feedbackId,
-      userId: user?.rowId,
-    },
-    {
-      select: (data) => data?.post,
-    },
+  const { data: feedback } = useQuery(
+    feedbackByIdOptions({ rowId: feedbackId, userId: user?.rowId }),
   );
 
   const { isAdmin } = useOrganizationMembership({

--- a/src/components/feedback/UpdateFeedback/UpdateFeedback.tsx
+++ b/src/components/feedback/UpdateFeedback/UpdateFeedback.tsx
@@ -15,12 +15,13 @@ import { useIsClient } from "usehooks-ts";
 import { z } from "zod";
 
 import { CharacterLimit } from "components/core";
-import { useFeedbackByIdQuery, useUpdatePostMutation } from "generated/graphql";
+import { useUpdatePostMutation } from "generated/graphql";
 import { token } from "generated/panda/tokens";
 import { app } from "lib/config";
 import { DEBOUNCE_TIME, standardRegexSchema } from "lib/constants";
 import { useForm, useViewportSize } from "lib/hooks";
 import { toaster } from "lib/util";
+import { feedbackByIdOptions } from "lib/options";
 
 import type { DialogProps } from "@omnidev/sigil";
 import type { FeedbackFragment } from "generated/graphql";
@@ -76,12 +77,12 @@ const UpdateFeedback = ({ user, feedback, ...rest }: Props) => {
         queryClient.invalidateQueries({
           queryKey: ["Posts.infinite"],
         }),
-        queryClient.invalidateQueries({
-          queryKey: useFeedbackByIdQuery.getKey({
+        queryClient.invalidateQueries(
+          feedbackByIdOptions({
             rowId: feedback.rowId!,
             userId: user?.rowId,
           }),
-        }),
+        ),
       ]);
     },
     onSuccess: () => {

--- a/src/components/project/ProjectSettings/ProjectSettings.tsx
+++ b/src/components/project/ProjectSettings/ProjectSettings.tsx
@@ -69,7 +69,7 @@ const ProjectSettings = ({ user, projectId, organizationSlug }: Props) => {
 
   return (
     <Stack gap={6}>
-      <UpdateProject />
+      <UpdateProject user={user} />
 
       <SectionContainer
         title={app.projectSettingsPage.dangerZone.title}

--- a/src/components/project/UpdateStatuses/UpdateStatuses.tsx
+++ b/src/components/project/UpdateStatuses/UpdateStatuses.tsx
@@ -39,6 +39,8 @@ import { toaster } from "lib/util";
 
 import type { Project } from "generated/graphql";
 
+// TODO: handle loading states properly for when an admin updates project name and gets rerouted based on updated slug
+
 interface FieldInfo {
   info?: string;
 }
@@ -110,7 +112,8 @@ const UpdateStatuses = ({ projectId }: Props) => {
       projectId,
     },
     {
-      enabled: isDevEnv,
+      // NB: if a project name is updated and the slug changes, `projectId` will initially be undefined as `router.replace` will just perform a client side navigation and the "new project" is not prefetched
+      enabled: isDevEnv && !!projectId,
       select: (data) =>
         data.postStatuses?.nodes?.map((status) => ({
           rowId: status?.rowId,

--- a/src/lib/hooks/mutations/useHandleDownvoteMutation.tsx
+++ b/src/lib/hooks/mutations/useHandleDownvoteMutation.tsx
@@ -4,11 +4,10 @@ import {
   useCreateDownvoteMutation,
   useDeleteDownvoteMutation,
   useDeleteUpvoteMutation,
-  useFeedbackByIdQuery,
   useProjectMetricsQuery,
 } from "generated/graphql";
 import { useAuth, useSearchParams } from "lib/hooks";
-import { infinitePostsOptions } from "lib/options";
+import { feedbackByIdOptions, infinitePostsOptions } from "lib/options";
 
 import type { InfiniteData, UseMutationOptions } from "@tanstack/react-query";
 import type {
@@ -81,8 +80,13 @@ const useHandleDownvoteMutation = ({
       }
     },
     onMutate: async () => {
+      const feedbackQueryKey = feedbackByIdOptions({
+        rowId: feedbackId,
+        userId: user?.rowId,
+      }).queryKey;
+
       const feedbackSnapshot = queryClient.getQueryData(
-        useFeedbackByIdQuery.getKey({ rowId: feedbackId, userId: user?.rowId }),
+        feedbackQueryKey,
       ) as FeedbackByIdQuery;
 
       const postsQueryKey = infinitePostsOptions({
@@ -97,35 +101,29 @@ const useHandleDownvoteMutation = ({
         queryClient.getQueryData<InfiniteData<PostsQuery>>(postsQueryKey);
 
       if (feedbackSnapshot) {
-        queryClient.setQueryData(
-          useFeedbackByIdQuery.getKey({
-            rowId: feedbackId,
-            userId: user?.rowId,
-          }),
-          {
-            post: {
-              ...feedbackSnapshot?.post,
-              userDownvotes: {
-                nodes: downvote ? [] : [{ rowId: "pending" }],
-              },
-              userUpvotes: {
-                nodes: downvote ? feedbackSnapshot?.post?.userUpvotes : [],
-              },
-              downvotes: {
-                ...feedbackSnapshot?.post?.downvotes,
-                totalCount:
-                  (feedbackSnapshot?.post?.downvotes?.totalCount ?? 0) +
-                  (downvote ? -1 : 1),
-              },
-              upvotes: {
-                ...feedbackSnapshot?.post?.upvotes,
-                totalCount:
-                  (feedbackSnapshot?.post?.upvotes?.totalCount ?? 0) +
-                  (upvote ? -1 : 0),
-              },
+        queryClient.setQueryData(feedbackQueryKey, {
+          post: {
+            ...feedbackSnapshot?.post,
+            userDownvotes: {
+              nodes: downvote ? [] : [{ rowId: "pending" }],
+            },
+            userUpvotes: {
+              nodes: downvote ? feedbackSnapshot?.post?.userUpvotes : [],
+            },
+            downvotes: {
+              ...feedbackSnapshot?.post?.downvotes,
+              totalCount:
+                (feedbackSnapshot?.post?.downvotes?.totalCount ?? 0) +
+                (downvote ? -1 : 1),
+            },
+            upvotes: {
+              ...feedbackSnapshot?.post?.upvotes,
+              totalCount:
+                (feedbackSnapshot?.post?.upvotes?.totalCount ?? 0) +
+                (upvote ? -1 : 0),
             },
           },
-        );
+        } as FeedbackByIdQuery);
       }
 
       if (postsSnapshot) {
@@ -178,21 +176,15 @@ const useHandleDownvoteMutation = ({
           }),
         ]);
 
-        return queryClient.invalidateQueries({
-          queryKey: useFeedbackByIdQuery.getKey({
-            rowId: feedbackId,
-            userId: user?.rowId,
-          }),
-        });
+        return queryClient.invalidateQueries(
+          feedbackByIdOptions({ rowId: feedbackId, userId: user?.rowId }),
+        );
       }
 
       await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: useFeedbackByIdQuery.getKey({
-            rowId: feedbackId,
-            userId: user?.rowId,
-          }),
-        }),
+        queryClient.invalidateQueries(
+          feedbackByIdOptions({ rowId: feedbackId, userId: user?.rowId }),
+        ),
         queryClient.invalidateQueries({
           queryKey: useProjectMetricsQuery.getKey({ projectId }),
         }),

--- a/src/lib/options/feedbackById.options.ts
+++ b/src/lib/options/feedbackById.options.ts
@@ -1,0 +1,22 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { useFeedbackByIdQuery } from "generated/graphql";
+
+import type { FeedbackByIdQueryVariables } from "generated/graphql";
+
+interface Options extends FeedbackByIdQueryVariables {
+  /* Authenticated user ID. */
+  userId: FeedbackByIdQueryVariables["userId"];
+}
+
+/**
+ * Options for the feedback by ID query.
+ */
+const feedbackByIdOptions = (options: Options) =>
+  queryOptions({
+    queryKey: useFeedbackByIdQuery.getKey(options),
+    queryFn: useFeedbackByIdQuery.fetcher(options),
+    select: (data) => data?.post,
+  });
+
+export default feedbackByIdOptions;

--- a/src/lib/options/index.ts
+++ b/src/lib/options/index.ts
@@ -1,3 +1,4 @@
 export { default as freeTierCommentsOptions } from "./freeTierComments.options";
 export { default as freeTierFeedbackOptions } from "./freeTierFeedback.options";
+export { default as infinitePostsOptions } from "./infinitePosts.options";
 export { default as subscriptionOptions } from "./subscription.options";

--- a/src/lib/options/index.ts
+++ b/src/lib/options/index.ts
@@ -1,3 +1,4 @@
+export { default as feedbackByIdOptions } from "./feedbackById.options";
 export { default as freeTierCommentsOptions } from "./freeTierComments.options";
 export { default as freeTierFeedbackOptions } from "./freeTierFeedback.options";
 export { default as infinitePostsOptions } from "./infinitePosts.options";

--- a/src/lib/options/index.ts
+++ b/src/lib/options/index.ts
@@ -2,4 +2,5 @@ export { default as feedbackByIdOptions } from "./feedbackById.options";
 export { default as freeTierCommentsOptions } from "./freeTierComments.options";
 export { default as freeTierFeedbackOptions } from "./freeTierFeedback.options";
 export { default as infinitePostsOptions } from "./infinitePosts.options";
+export { default as projectOptions } from "./project.options";
 export { default as subscriptionOptions } from "./subscription.options";

--- a/src/lib/options/infinitePosts.options.ts
+++ b/src/lib/options/infinitePosts.options.ts
@@ -1,0 +1,40 @@
+import { infiniteQueryOptions } from "@tanstack/react-query";
+
+import {
+  PostOrderBy,
+  useInfinitePostsQuery,
+  usePostsQuery,
+} from "generated/graphql";
+
+import type { PostsQueryVariables } from "generated/graphql";
+
+interface Options extends Omit<PostsQueryVariables, "orderBy"> {
+  /* Authenticated user ID. */
+  userId: PostsQueryVariables["userId"];
+  /** Order by option for posts. Derived from search parameters. */
+  orderBy: string | null;
+}
+
+/**
+ * Options for the infinite posts query.
+ */
+const infinitePostsOptions = (options: Options) => {
+  const variables: PostsQueryVariables = {
+    ...options,
+    orderBy: options.orderBy
+      ? [options.orderBy as PostOrderBy, PostOrderBy.CreatedAtDesc]
+      : undefined,
+  };
+
+  return infiniteQueryOptions({
+    queryKey: useInfinitePostsQuery.getKey(variables),
+    queryFn: usePostsQuery.fetcher(variables),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage?.posts?.pageInfo?.hasNextPage
+        ? { after: lastPage?.posts?.pageInfo?.endCursor }
+        : undefined,
+  });
+};
+
+export default infinitePostsOptions;

--- a/src/lib/options/project.options.ts
+++ b/src/lib/options/project.options.ts
@@ -1,0 +1,18 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { useProjectQuery } from "generated/graphql";
+
+import type { ProjectQueryVariables } from "generated/graphql";
+
+interface Options extends ProjectQueryVariables {
+  /* Authenticated user ID. */
+  userId: ProjectQueryVariables["userId"];
+}
+
+const projectOptions = (options: Options) =>
+  queryOptions({
+    queryKey: useProjectQuery.getKey(options),
+    queryFn: useProjectQuery.fetcher(options),
+  });
+
+export default projectOptions;


### PR DESCRIPTION
## Description

Currently, for most queries, we rely on the generated hooks from graphql codegen. These are wonderful and provide a lot of value for sure. In some instances however, relying on them for type safety has caused issues witch mismatched query keys across different patterns like `invalidateQueries`, `prefetchQuery`, etc. This is due to some unintended drift as we build out features and expand on query variables. One of the most noteworthy examples of this drift was fixed in [this PR](https://github.com/omnidotdev/backfeed-app/pull/139) where an update to how the `FeedbackByIdQuery` and `PostsQuery` was handled to properly pass in the `userId` for said queries in the places where it was missed. This was important because logic depended on that variable to properly fetch i.e. `userUpvotes` but without the `userId` would return the first of *all* upvotes regardless if it was an upvote made by the user.

This PR fixes this issue for a limited set of queries that currently have `userId` as an optional variable. What is done here is that designated query options are defined, and the type safety is improved by *requiring* `userId` to be passed as a variable even if it is undefined. This same pattern can be extended upon and used to enforce any variable to be a required option. This also limits drift for updating certain variables (i.e. `orderBy`) to make sure that query key management is appropriate, as well as deduplicates necessary code to apply patterns like `invalidateQueries` and `prefetchQuery`.

## Test Steps

1) Verify that logic is sound
2) Verify that functionality across effected queries, prefetches, and invalidations is intact
3) Verify that type safety works as expected (i.e. `userId` is a required variable to be passed into the options)
