### PR TITLE
Static OAuth client credentials

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -1,9 +1,9 @@
 # auth
 # NB: an auth secret can be generated and injected automatically with `npx auth`, see https://cli.authjs.dev
 AUTH_SECRET=""
-# get a client ID and secret from HIDRA app
-AUTH_CLIENT_ID=""
-AUTH_CLIENT_SECRET=""
+# OAuth client credentials, must match an allowed OAuth application in the IDP
+AUTH_CLIENT_ID="CZciMWzWjHUSsPLjVOzNKaPWZHNebQux"
+AUTH_CLIENT_SECRET="vxKWdwVAwZdetUnjLxaDuYonZjxGuBUE"
 
 # payment processing
 # NB: for local development, make sure this token is generated for the Polar sandbox environment (https://docs.polar.sh/integrate/sandbox) in the Polar dashboard. If `NODE_ENV` is `development`, the sandbox will be used, otherwise Polar production will be used


### PR DESCRIPTION
## Description

##### Task link: N/A

- Set static OAuth client credentials matching IDP in development

## Test Steps

- Set the new environment variables in `.env.local`
- Verify login works (Backfeed -> Sign In -> IDP -> authenticated in Backfeed)
- Be happy: no more manual OAuth application setup during development in Omni OIDC RPs!
