### PR TITLE
fix(auth): resolve user rowId via observer query

### DIFF
--- a/src/lib/auth/getAuth.ts
+++ b/src/lib/auth/getAuth.ts
@@ -15,22 +15,23 @@ export type {
 } from "@omnidotdev/providers/auth";
 
 /**
- * Resolve the app's user-row UUID from the GraphQL API by identity provider ID.
+ * Resolve the app's user-row UUID from the GraphQL API for the authenticated
+ * caller. Uses the `observer` query, which the API resolves from the bearer
+ * access token, so it does not depend on the OIDC `sub` being a valid UUID or
+ * matching a stored `identityProviderId` column.
+ *
  * Populates `session.user.rowId`, which gates the dashboard redirect and is used
  * as the current user identity throughout the app (votes, comments, profile).
  */
-export const resolveRowId: ResolveRowIdFn = async ({
-  accessToken,
-  identityProviderId,
-}) => {
+export const resolveRowId: ResolveRowIdFn = async ({ accessToken }) => {
   try {
     const graphqlClient = new GraphQLClient(API_INTERNAL_GRAPHQL_URL!, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     const sdk = getSdk(graphqlClient);
-    const { userByIdentityProviderId } = await sdk.User({ identityProviderId });
+    const { observer } = await sdk.Observer();
 
-    return userByIdentityProviderId?.rowId ?? null;
+    return observer?.rowId ?? null;
   } catch (error) {
     console.error("[getAuth] Failed to resolve rowId:", error);
     return null;


### PR DESCRIPTION
## Description

##### Task link: https://...

After login, authenticated users were stranded on the landing page. The landing route gates on `session.user.rowId`, which was `null` because `resolveRowId` resolved via `userByIdentityProviderId(identityProviderId: $sub)` keyed on the OIDC `sub`. That lookup returns null when `sub` is not a valid `UUID` or does not match the API's stored `identityProviderId`, and the null was then cached.

This switches `resolveRowId` to the token-based `observer` query (the API identifies the caller from the bearer token), matching the working runa pattern. The `User` query is left in place since the profile route still uses it.

## Test Steps

1. Log out (clears the `backfeed` auth-cache cookie), then log back in.
2. Confirm you land on `/dashboard` rather than the landing page.
3. Confirm votes/comments/profile still resolve the current user.