### PR TITLE
fix(feedback): don't block post creation when no status templates exist

### DIFF
--- a/src/components/feedback/CreateFeedback.tsx
+++ b/src/components/feedback/CreateFeedback.tsx
@@ -106,20 +106,15 @@ const CreateFeedback = () => {
           return;
         }
 
-        if (!defaultStatusTemplateId) {
-          toaster.error({
-            title: app.projectPage.projectFeedback.action.error.title,
-            description:
-              "Status templates are not configured. Please contact a workspace admin.",
-          });
-          return;
-        }
-
         return toaster.promise(
           createFeedback({
             input: {
               post: {
-                statusTemplateId: defaultStatusTemplateId,
+                // status is optional; a project without configured status
+                // templates still accepts posts (they start without a status)
+                ...(defaultStatusTemplateId && {
+                  statusTemplateId: defaultStatusTemplateId,
+                }),
                 projectId,
                 userId: session.user.rowId,
                 title: value.title.trim(),


### PR DESCRIPTION
## Description

##### Task link: N/A

Reporting feedback / creating a post hard-failed with "Status templates are not configured. Please contact a workspace admin." when the project's organization had no status templates. That copy points end users (often unauthenticated) at something they can't fix, and `statusTemplateId` is optional anyway.

This removes the hard block: when no default status template is available, the post is submitted **without** one (the column is nullable), so creation always succeeds and the confusing toast is gone.

Note: orgs missing default templates can still be backfilled server-side via backfeed-api's `backfillStatusTemplates.ts` script (production needs that run once).

## Test Steps

1. In a project whose org has no status templates, create a post -> it succeeds (no error toast).
2. In a project with templates -> post still gets the default ("open") status as before.