### PR TITLE
refactor(pricing): convert PricingHeader to Tailwind

### DIFF
--- a/src/components/pricing/PricingHeader.tsx
+++ b/src/components/pricing/PricingHeader.tsx
@@ -1,32 +1,18 @@
-import { Flex, Text } from "@omnidev/sigil";
-
 import app from "@/lib/config/app.config";
 
 /**
  * Pricing header.
  */
 const PricingHeader = () => (
-  <Flex align="center" direction="column">
-    <Text
-      as="h1"
-      fontSize={{ base: "4xl", lg: "5xl" }}
-      fontWeight="bold"
-      textAlign="center"
-      mt={4}
-    >
+  <div className="flex flex-col items-center">
+    <h1 className="mt-4 text-center font-bold text-4xl lg:text-5xl">
       {app.pricingPage.pricingHeader.title}
-    </Text>
+    </h1>
 
-    <Text
-      fontSize={{ base: "xl", lg: "2xl" }}
-      maxW={{ md: "70%" }}
-      textAlign="center"
-      textWrap="pretty"
-      m={4}
-    >
+    <p className="m-4 text-pretty text-center text-xl md:max-w-[70%] lg:text-2xl">
       {app.pricingPage.pricingHeader.description}
-    </Text>
-  </Flex>
+    </p>
+  </div>
 );
 
 export default PricingHeader;


### PR DESCRIPTION
## Description

##### Task link: N/A

First real component conversion in the Panda/Sigil -> Tailwind/shadcn migration (on the #184 foundation). `PricingHeader` (Sigil `Flex`/`Text` -> `div`/`h1`/`p`), a faithful 1:1 mapping of the style props (`fontSize 4xl/5xl` -> `text-4xl lg:text-5xl`, `mt={4}` -> `mt-4`, etc.).

Low blast radius: used only on the pricing page. **Please eyeball `/pricing` to confirm the mapping is visually faithful before I propagate the pattern across the rest, catching any systematic token mismatch on one component is much cheaper than after 95.**

## Test Steps

1. `bunx tsc --noEmit` + `bun run build` -> clean (verified)
2. Visit `/pricing` -> header renders identically to before.