### PR TITLE
feat(ui): add Input and Card shadcn primitives

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,112 @@
+import { ark } from "@ark-ui/react";
+
+import cn from "@/lib/utils";
+
+import type { ComponentProps, ReactNode } from "react";
+
+const CardRoot = ({ className, ...rest }: ComponentProps<typeof ark.div>) => (
+  <ark.div
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const CardHeader = ({ className, ...rest }: ComponentProps<typeof ark.div>) => (
+  <ark.div className={cn("flex flex-col gap-1.5 p-6", className)} {...rest} />
+);
+
+const CardTitle = ({ className, ...rest }: ComponentProps<typeof ark.div>) => (
+  <ark.div
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...rest}
+  />
+);
+
+const CardDescription = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ark.div>) => (
+  <ark.div
+    className={cn("text-muted-foreground text-sm", className)}
+    {...rest}
+  />
+);
+
+const CardContent = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ark.div>) => (
+  <ark.div className={cn("p-6 pt-0", className)} {...rest} />
+);
+
+const CardFooter = ({ className, ...rest }: ComponentProps<typeof ark.div>) => (
+  <ark.div className={cn("flex items-center p-6 pt-0", className)} {...rest} />
+);
+
+interface CardProps extends ComponentProps<typeof CardRoot> {
+  title?: string;
+  description?: string;
+  footer?: ReactNode;
+  /**
+   * @remarks `ComponentProps<typeof CardHeader>`
+   */
+  headerProps?: ComponentProps<typeof CardHeader>;
+  /**
+   * @remarks `ComponentProps<typeof CardTitle>`
+   */
+  titleProps?: ComponentProps<typeof CardTitle>;
+  /**
+   * @remarks `ComponentProps<typeof CardDescription>`
+   */
+  descriptionProps?: ComponentProps<typeof CardDescription>;
+  /**
+   * @remarks `ComponentProps<typeof CardContent>`
+   */
+  contentProps?: ComponentProps<typeof CardContent>;
+  /**
+   * @remarks `ComponentProps<typeof CardFooter>`
+   */
+  footerProps?: ComponentProps<typeof CardFooter>;
+}
+
+const Card = ({
+  title,
+  description,
+  footer,
+  headerProps,
+  titleProps,
+  descriptionProps,
+  contentProps,
+  footerProps,
+  children,
+  ...rest
+}: CardProps) => (
+  <CardRoot {...rest}>
+    {(title || description) && (
+      <CardHeader {...headerProps}>
+        {title && <CardTitle {...titleProps}>{title}</CardTitle>}
+        {description && (
+          <CardDescription {...descriptionProps}>{description}</CardDescription>
+        )}
+      </CardHeader>
+    )}
+
+    <CardContent {...contentProps}>{children}</CardContent>
+
+    {footer && <CardFooter {...footerProps}>{footer}</CardFooter>}
+  </CardRoot>
+);
+
+export {
+  Card,
+  CardRoot,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  type CardProps,
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,17 @@
+import { ark } from "@ark-ui/react";
+
+import cn from "@/lib/utils";
+
+import type { ComponentProps } from "react";
+
+const Input = ({ className, ...rest }: ComponentProps<typeof ark.input>) => (
+  <ark.input
+    className={cn(
+      "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:font-medium file:text-foreground file:text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+export { Input };

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -21,6 +21,9 @@
   --color-accent: var(--colors-accent-default);
   --color-accent-foreground: var(--colors-accent-foreground);
   --color-destructive: var(--colors-status-error, oklch(0.577 0.245 27.325));
+  --color-card-foreground: var(--colors-foreground-default);
+  --color-input: var(--colors-border-default);
+  --color-ring: var(--colors-brand-primary);
   --radius-sm: 0.375rem;
   --radius-md: 0.5rem;
   --radius-lg: 0.625rem;


### PR DESCRIPTION
## Description

##### Task link: N/A

Expands the shadcn component library (after the #184 foundation) with `Input` and `Card`, ported from fractal-app, plus the supporting theme tokens (`input`, `ring`, `card-foreground`). **Additive adoptable scaffolding, no rendering change** (tree-shaken until imported).

## Test Steps

1. `bun run build` + `bunx tsc --noEmit` + `bun knip` -> clean (verified)
2. No visual change (not yet imported).