### PR TITLE
refactor(project): convert ProjectFilters to shadcn Input

### DIFF
--- a/src/components/project/ProjectFilters.tsx
+++ b/src/components/project/ProjectFilters.tsx
@@ -1,6 +1,6 @@
-import { Grid, GridItem, Input } from "@omnidev/sigil";
 import { getRouteApi } from "@tanstack/react-router";
 
+import { Input } from "@/components/ui/input";
 import app from "@/lib/config/app.config";
 import useHandleSearch from "@/lib/hooks/useHandleSearch";
 
@@ -17,16 +17,13 @@ const ProjectFilters = () => {
   const onSearchChange = useHandleSearch();
 
   return (
-    <Grid w="full">
-      <GridItem>
-        <Input
-          borderColor="border.subtle"
-          placeholder={app.projectsPage.filters.search.placeholder}
-          defaultValue={search}
-          onChange={onSearchChange}
-        />
-      </GridItem>
-    </Grid>
+    <div className="w-full">
+      <Input
+        placeholder={app.projectsPage.filters.search.placeholder}
+        defaultValue={search}
+        onChange={onSearchChange}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description

##### Task link: N/A

Converts `ProjectFilters` off Sigil (Grid/Input) to a div + the shadcn `Input` primitive. First real adoption of `Input`; search behavior unchanged.

## Test Steps
1. `bunx tsc --noEmit` clean (verified)
2. Projects page search input renders + filters as before.