### PR TITLE
feat(ui): port remaining shadcn primitives

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "dayjs": "^1.11.19",
         "graphql": "^16.12.0",
         "graphql-request": "^7.4.0",
+        "lucide-react": "^0.563.0",
         "motion": "^12.25.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
@@ -1816,6 +1817,8 @@
     "lower-case-first": ["lower-case-first@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg=="],
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
+    "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -42,6 +42,7 @@ const knipConfig: KnipConfig = {
     "class-variance-authority",
     "clsx",
     "tailwind-merge",
+    "lucide-react",
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dayjs": "^1.11.19",
     "graphql": "^16.12.0",
     "graphql-request": "^7.4.0",
+    "lucide-react": "^0.563.0",
     "motion": "^12.25.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,80 @@
+import { Accordion as ArkAccordion } from "@ark-ui/react";
+import { ChevronDown } from "lucide-react";
+
+import cn from "@/lib/utils";
+
+import type {
+  AccordionItemContentProps,
+  AccordionItemProps,
+  AccordionItemTriggerProps,
+  AccordionRootProps,
+} from "@ark-ui/react";
+import type { ElementType } from "react";
+
+const AccordionRoot = ({ className, ...rest }: AccordionRootProps) => (
+  <ArkAccordion.Root
+    className={cn(
+      "flex flex-col data-[orientation=horizontal]:flex-row data-[orientation=horizontal]:gap-4 data-[orientation=horizontal]:border-none",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const AccordionItem = ({ className, ...rest }: AccordionItemProps) => (
+  <ArkAccordion.Item
+    className={cn(
+      "group flex flex-col border-b data-[orientation=horizontal]:w-full data-[orientation=horizontal]:border-none data-disabled:opacity-50",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+interface ItemTriggerProps extends AccordionItemTriggerProps {
+  icon?: ElementType;
+}
+
+const AccordionItemTrigger = ({
+  className,
+  children,
+  icon,
+  ...rest
+}: ItemTriggerProps) => {
+  const Icon = icon ?? ChevronDown;
+
+  return (
+    <ArkAccordion.ItemTrigger
+      className={cn(
+        "flex flex-1 cursor-pointer items-center justify-between rounded-md px-2 py-4 text-left font-medium text-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed data-[orientation=horizontal]:items-start [&[data-state=open]>svg]:rotate-180",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+      <Icon className="size-4 transition-transform" />
+    </ArkAccordion.ItemTrigger>
+  );
+};
+
+const AccordionItemContent = ({
+  className,
+  children,
+  ...rest
+}: AccordionItemContentProps) => (
+  <ArkAccordion.ItemContent
+    className={
+      "overflow-hidden px-2 text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    }
+    {...rest}
+  >
+    <div className={cn("pt-0 pb-4", className)}>{children}</div>
+  </ArkAccordion.ItemContent>
+);
+
+export {
+  AccordionRoot,
+  AccordionItem,
+  AccordionItemTrigger,
+  AccordionItemContent,
+};

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,61 @@
+import { Avatar as ArkAvatar } from "@ark-ui/react";
+import { cva } from "class-variance-authority";
+
+import cn from "@/lib/utils";
+
+import type { VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
+
+const avatarVariants = cva(
+  "relative flex shrink-0 items-center justify-center overflow-hidden rounded-full",
+  {
+    variants: {
+      size: {
+        xs: "size-8 text-xs",
+        sm: "size-9 text-sm",
+        md: "size-10 text-md",
+        lg: "size-11 text-lg",
+        xl: "size-12 text-xl",
+      },
+    },
+    defaultVariants: { size: "md" },
+  },
+);
+
+const AvatarRoot = ({
+  className,
+  size,
+  ...rest
+}: ComponentProps<typeof ArkAvatar.Root> &
+  VariantProps<typeof avatarVariants>) => (
+  <ArkAvatar.Root
+    className={cn(avatarVariants({ size, className }))}
+    {...rest}
+  />
+);
+
+const AvatarFallback = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkAvatar.Fallback>) => (
+  <ArkAvatar.Fallback
+    className={cn(
+      "flex size-full items-center justify-center rounded-full bg-muted",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const AvatarImage = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkAvatar.Image>) => (
+  <ArkAvatar.Image
+    className={cn("aspect-square size-full", className)}
+    alt="Avatar"
+    {...rest}
+  />
+);
+
+export { AvatarRoot, AvatarFallback, AvatarImage };

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,38 @@
+import { ark } from "@ark-ui/react";
+import { cva } from "class-variance-authority";
+
+import cn from "@/lib/utils";
+
+import type { VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-full border px-2 py-0.5 font-medium text-xs transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        solid:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "solid",
+    },
+  },
+);
+
+const Badge = ({
+  className,
+  variant,
+  ...rest
+}: ComponentProps<typeof ark.div> & VariantProps<typeof badgeVariants>) => (
+  <ark.div className={cn(badgeVariants({ variant }), className)} {...rest} />
+);
+
+export { Badge, badgeVariants };

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,0 +1,82 @@
+import {
+  Combobox as ArkCombobox,
+  createListCollection,
+} from "@ark-ui/react/combobox";
+import { Portal } from "@ark-ui/react/portal";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useMemo } from "react";
+
+type Item = {
+  label: string;
+  value: string;
+  disabled?: boolean;
+};
+
+type ComboboxProps = {
+  items: Item[];
+  placeholder?: string;
+  value?: string[];
+  onValueChange?: (value: string[]) => void;
+  inputValue?: string;
+  onInputValueChange?: (value: string) => void;
+  disabled?: boolean;
+};
+
+const Combobox = ({
+  items,
+  placeholder = "Select...",
+  value,
+  onValueChange,
+  inputValue,
+  onInputValueChange,
+  disabled,
+}: ComboboxProps) => {
+  const collection = useMemo(() => createListCollection({ items }), [items]);
+
+  return (
+    <ArkCombobox.Root
+      collection={collection}
+      value={value}
+      onValueChange={(details) => onValueChange?.(details.value)}
+      inputValue={inputValue}
+      onInputValueChange={(details) => onInputValueChange?.(details.inputValue)}
+      disabled={disabled}
+      loopFocus
+    >
+      <ArkCombobox.Control className="relative">
+        <ArkCombobox.Input
+          placeholder={placeholder}
+          className="w-full rounded-lg border border-input bg-muted px-3 py-2 pr-8 text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <ArkCombobox.Trigger className="absolute top-1/2 right-2 -translate-y-1/2">
+          <ChevronsUpDown className="size-4 text-muted-foreground" />
+        </ArkCombobox.Trigger>
+      </ArkCombobox.Control>
+
+      <Portal>
+        <ArkCombobox.Positioner>
+          <ArkCombobox.Content className="z-50 max-h-60 w-[var(--reference-width)] overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-md">
+            {items.map((item) => (
+              <ArkCombobox.Item
+                key={item.value}
+                item={item}
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-popover-foreground text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+              >
+                <ArkCombobox.ItemIndicator>
+                  <Check className="size-4" />
+                </ArkCombobox.ItemIndicator>
+                <ArkCombobox.ItemText>{item.label}</ArkCombobox.ItemText>
+              </ArkCombobox.Item>
+            ))}
+
+            <ArkCombobox.Empty className="px-2 py-4 text-center text-muted-foreground text-sm">
+              No results
+            </ArkCombobox.Empty>
+          </ArkCombobox.Content>
+        </ArkCombobox.Positioner>
+      </Portal>
+    </ArkCombobox.Root>
+  );
+};
+
+export default Combobox;

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,101 @@
+import { Dialog as ArkDialog } from "@ark-ui/react";
+import { X } from "lucide-react";
+
+import cn from "@/lib/utils";
+
+import type { ComponentProps } from "react";
+
+const DialogRoot = ArkDialog.Root;
+
+const DialogBackdrop = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkDialog.Backdrop>) => (
+  <ArkDialog.Backdrop
+    className={cn(
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=closed]:animate-out data-[state=open]:animate-in",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const DialogPositioner = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkDialog.Positioner>) => (
+  <ArkDialog.Positioner
+    className={cn(
+      "fixed inset-0 z-50 flex items-center justify-center p-4",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const DialogContent = ({
+  className,
+  children,
+  ...rest
+}: ComponentProps<typeof ArkDialog.Content>) => (
+  <DialogPositioner>
+    <ArkDialog.Content
+      className={cn(
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-bottom-1/2 data-[state=open]:slide-in-from-bottom-1/2 relative w-full max-w-lg rounded-xl border bg-background p-6 shadow-2xl data-[state=closed]:animate-out data-[state=open]:animate-in",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </ArkDialog.Content>
+  </DialogPositioner>
+);
+
+const DialogCloseTrigger = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkDialog.CloseTrigger>) => (
+  <ArkDialog.CloseTrigger
+    className={cn(
+      "absolute top-4 right-4 rounded-lg p-1.5 text-muted-foreground opacity-70 transition-all hover:bg-accent hover:text-accent-foreground hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
+      className,
+    )}
+    {...rest}
+  >
+    <X className="size-4" />
+    <span className="sr-only">Close</span>
+  </ArkDialog.CloseTrigger>
+);
+
+const DialogTitle = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkDialog.Title>) => (
+  <ArkDialog.Title
+    className={cn(
+      "mb-2 font-semibold text-foreground text-lg leading-none tracking-tight",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const DialogDescription = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkDialog.Description>) => (
+  <ArkDialog.Description
+    className={cn("mb-4 text-muted-foreground text-sm", className)}
+    {...rest}
+  />
+);
+
+export {
+  DialogRoot,
+  DialogBackdrop,
+  DialogPositioner,
+  DialogContent,
+  DialogCloseTrigger,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/components/ui/menu.tsx
+++ b/src/components/ui/menu.tsx
@@ -1,0 +1,109 @@
+import { Menu as ArkMenu } from "@ark-ui/react/menu";
+
+import cn from "@/lib/utils";
+
+import type { ComponentProps } from "react";
+
+const MenuRoot = ArkMenu.Root;
+
+const MenuContextTrigger = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkMenu.ContextTrigger>) => (
+  <ArkMenu.ContextTrigger className={className} {...rest} />
+);
+
+const MenuTrigger = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkMenu.Trigger>) => (
+  <ArkMenu.Trigger className={className} {...rest} />
+);
+
+const MenuPositioner = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkMenu.Positioner>) => (
+  <ArkMenu.Positioner className={className} {...rest} />
+);
+
+const MenuContent = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkMenu.Content>) => (
+  <ArkMenu.Content
+    className={cn(
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 flex min-w-32 origin-(--transform-origin) flex-col gap-0.5 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none duration-300 data-[state=closed]:animate-out data-[state=open]:animate-in",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const MenuItem = ({
+  className,
+  children,
+  variant,
+  ...rest
+}: ComponentProps<typeof ArkMenu.Item> & { variant?: "destructive" }) => (
+  <ArkMenu.Item
+    data-variant={variant}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden hover:bg-accent focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-[state=checked]:bg-accent data-highlighted:bg-accent data-inset:pl-8 data-[state=checked]:text-accent-foreground data-[variant=destructive]:text-destructive data-highlighted:text-accent-foreground data-disabled:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:hover:bg-destructive/10 dark:data-[variant=destructive]:hover:bg-destructive/20 [&[data-state=checked][data-highlighted]]:bg-sidebar-accent/80 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 data-[variant=destructive]:*:[svg]:text-destructive!",
+      className,
+    )}
+    {...rest}
+  >
+    {children}
+  </ArkMenu.Item>
+);
+
+const MenuItemGroup = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkMenu.ItemGroup>) => (
+  <ArkMenu.ItemGroup className={cn("overflow-hidden", className)} {...rest} />
+);
+
+const MenuItemGroupLabel = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkMenu.ItemGroupLabel>) => (
+  <ArkMenu.ItemGroupLabel
+    className={cn(
+      "flex w-full items-center justify-between p-2 font-medium text-foreground text-sm",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const MenuItemText = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkMenu.ItemText>) => (
+  <ArkMenu.ItemText className={className} {...rest} />
+);
+
+const MenuSeparator = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkMenu.Separator>) => (
+  <ArkMenu.Separator
+    className={cn("-mx-1 mt-1 mb-1 h-px bg-border", className)}
+    {...rest}
+  />
+);
+
+export {
+  MenuContent,
+  MenuContextTrigger,
+  MenuItem,
+  MenuItemGroup,
+  MenuItemGroupLabel,
+  MenuItemText,
+  MenuPositioner,
+  MenuRoot,
+  MenuSeparator,
+  MenuTrigger,
+};

--- a/src/components/ui/segment-group.tsx
+++ b/src/components/ui/segment-group.tsx
@@ -1,0 +1,41 @@
+import { SegmentGroup as ArkSegmentGroup } from "@ark-ui/react/segment-group";
+
+import cn from "@/lib/utils";
+
+import type { ComponentProps } from "react";
+
+const SegmentGroupRoot = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSegmentGroup.Root>) => (
+  <ArkSegmentGroup.Root
+    className={cn(
+      "inline-flex items-center rounded-lg border border-border bg-muted p-0.5",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const SegmentGroupItem = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSegmentGroup.Item>) => (
+  <ArkSegmentGroup.Item
+    className={cn(
+      "relative cursor-pointer rounded-md px-3 py-1 text-muted-foreground text-sm transition-colors hover:text-foreground data-[state=checked]:bg-background data-[state=checked]:text-foreground data-[state=checked]:shadow-sm",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const SegmentGroupItemText = ArkSegmentGroup.ItemText;
+const SegmentGroupItemHiddenInput = ArkSegmentGroup.ItemHiddenInput;
+
+export {
+  SegmentGroupItem,
+  SegmentGroupItemHiddenInput,
+  SegmentGroupItemText,
+  SegmentGroupRoot,
+};

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,101 @@
+import { Portal } from "@ark-ui/react/portal";
+import { Select as ArkSelect } from "@ark-ui/react/select";
+import { ChevronDown } from "lucide-react";
+
+import cn from "@/lib/utils";
+
+import type { ComponentProps } from "react";
+
+const SelectRoot = ArkSelect.Root;
+
+const SelectControl = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSelect.Control>) => (
+  <ArkSelect.Control className={cn("relative", className)} {...rest} />
+);
+
+const SelectTrigger = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSelect.Trigger>) => (
+  <ArkSelect.Trigger
+    className={cn(
+      "inline-flex h-9 cursor-pointer items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-foreground text-sm shadow-xs outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const SelectValueText = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSelect.ValueText>) => (
+  <ArkSelect.ValueText className={cn("truncate", className)} {...rest} />
+);
+
+const SelectIndicator = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSelect.Indicator>) => (
+  <ArkSelect.Indicator className={className} {...rest}>
+    <ChevronDown className="size-4 text-muted-foreground" />
+  </ArkSelect.Indicator>
+);
+
+const SelectPositioner = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSelect.Positioner>) => (
+  <ArkSelect.Positioner className={className} {...rest} />
+);
+
+const SelectContent = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSelect.Content>) => (
+  <ArkSelect.Content
+    className={cn(
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 flex min-w-32 origin-(--transform-origin) flex-col gap-0.5 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const SelectItem = ({
+  className,
+  children,
+  ...rest
+}: ComponentProps<typeof ArkSelect.Item>) => (
+  <ArkSelect.Item
+    className={cn(
+      "relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden hover:bg-accent focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-50",
+      className,
+    )}
+    {...rest}
+  >
+    {children}
+  </ArkSelect.Item>
+);
+
+const SelectItemText = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSelect.ItemText>) => (
+  <ArkSelect.ItemText className={className} {...rest} />
+);
+
+export {
+  SelectContent,
+  SelectControl,
+  SelectIndicator,
+  SelectItem,
+  SelectItemText,
+  SelectPositioner,
+  SelectRoot,
+  SelectTrigger,
+  SelectValueText,
+  Portal as SelectPortal,
+};

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,45 @@
+import { Switch as ArkSwitch } from "@ark-ui/react/switch";
+
+import cn from "@/lib/utils";
+
+import type { ComponentProps } from "react";
+
+const SwitchRoot = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSwitch.Root>) => (
+  <ArkSwitch.Root
+    className={cn("inline-flex items-center gap-2", className)}
+    {...rest}
+  />
+);
+
+const SwitchControl = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSwitch.Control>) => (
+  <ArkSwitch.Control
+    className={cn(
+      "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent bg-input transition-colors data-disabled:cursor-not-allowed data-[state=checked]:bg-primary data-disabled:opacity-50",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const SwitchThumb = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkSwitch.Thumb>) => (
+  <ArkSwitch.Thumb
+    className={cn(
+      "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const SwitchHiddenInput = ArkSwitch.HiddenInput;
+
+export { SwitchControl, SwitchHiddenInput, SwitchRoot, SwitchThumb };

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,60 @@
+import cn from "@/lib/utils";
+
+import type { ComponentProps } from "react";
+
+interface TableProps extends ComponentProps<"table"> {
+  containerProps?: string;
+}
+
+const Table = ({ containerProps, className, ...rest }: TableProps) => (
+  <div
+    data-slot="table-container"
+    className={cn("no-scrollbar relative w-full overflow-auto", containerProps)}
+  >
+    <table
+      data-slot="table"
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...rest}
+    />
+  </div>
+);
+
+const TableHeader = ({ className, ...rest }: ComponentProps<"thead">) => (
+  <thead
+    data-slot="table-header"
+    className={cn("h-8 [&_tr]:border-b", className)}
+    {...rest}
+  />
+);
+
+const TableBody = ({ className, ...rest }: ComponentProps<"tbody">) => (
+  <tbody
+    data-slot="table-body"
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...rest}
+  />
+);
+
+const TableRow = ({ className, ...rest }: ComponentProps<"tr">) => (
+  <tr
+    data-slot="table-row"
+    className={cn(
+      "border-b hover:bg-accent data-[state=selected]:bg-accent",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const TableCell = ({ className, ...rest }: ComponentProps<"td">) => (
+  <td
+    data-slot="table-cell"
+    className={cn(
+      "select-none whitespace-nowrap align-middle font-light [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+export { Table, TableHeader, TableBody, TableRow, TableCell, type TableProps };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import { Tabs as ArkTabs } from "@ark-ui/react/tabs";
+
+import cn from "@/lib/utils";
+
+import type { ComponentProps } from "react";
+
+const TabsRoot = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkTabs.Root>) => (
+  <ArkTabs.Root className={cn("w-full", className)} {...rest} />
+);
+
+const TabsList = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkTabs.List>) => (
+  <ArkTabs.List
+    className={cn(
+      "inline-flex h-10 max-w-full items-center justify-start overflow-x-auto rounded-md bg-muted p-1 text-muted-foreground",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const TabsTrigger = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkTabs.Trigger>) => (
+  <ArkTabs.Trigger
+    className={cn(
+      "inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 font-medium text-sm ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 aria-selected:bg-background aria-selected:text-foreground aria-selected:shadow-sm",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+const TabsContent = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkTabs.Content>) => (
+  <ArkTabs.Content
+    className={cn(
+      "mt-2 rounded-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+export { TabsRoot, TabsList, TabsTrigger, TabsContent };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,36 @@
+import { Tooltip as ArkTooltip } from "@ark-ui/react/tooltip";
+
+import cn from "@/lib/utils";
+
+import type { ComponentProps } from "react";
+
+const TooltipRoot = ArkTooltip.Root;
+
+const TooltipTrigger = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkTooltip.Trigger>) => (
+  <ArkTooltip.Trigger className={className} {...rest} />
+);
+
+const TooltipPositioner = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkTooltip.Positioner>) => (
+  <ArkTooltip.Positioner className={className} {...rest} />
+);
+
+const TooltipContent = ({
+  className,
+  ...rest
+}: ComponentProps<typeof ArkTooltip.Content>) => (
+  <ArkTooltip.Content
+    className={cn(
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 rounded-md bg-popover px-2.5 py-1.5 text-popover-foreground text-xs shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
+      className,
+    )}
+    {...rest}
+  />
+);
+
+export { TooltipContent, TooltipPositioner, TooltipRoot, TooltipTrigger };


### PR DESCRIPTION
## Description

##### Task link: N/A

Completes the shadcn primitive library (on the #184/#186 foundation): accordion, avatar, badge, combobox, dialog, menu, segment-group, select, switch, table, tabs, tooltip, ported from fractal-app, plus lucide-react for icons.

**Additive adoptable scaffolding** (knip-ignored, tree-shaken until imported), so there is no rendering change. Full `bun run build` + `tsc` + `knip` verified.

This unblocks converting the feature components that depend on these primitives (Accordion, Badge, Dialog, Tooltip, etc.).

## Test Steps
1. `bun run build` + `bunx tsc --noEmit` + `bun knip` -> clean (verified)
2. No visual change (primitives not yet imported).