### PR TITLE
feat(ui): map Sigil semantic tokens to Tailwind

### DIFF
--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -24,6 +24,11 @@
   --color-card-foreground: var(--colors-foreground-default);
   --color-input: var(--colors-border-default);
   --color-ring: var(--colors-brand-primary);
+  /* Additional Sigil semantic tokens used across the app */
+  --color-foreground-subtle: var(--colors-foreground-subtle);
+  --color-border-subtle: var(--colors-border-subtle);
+  --color-background-subtle: var(--colors-background-subtle);
+  --color-background-emphasized: var(--colors-background-emphasized);
   --radius-sm: 0.375rem;
   --radius-md: 0.5rem;
   --radius-lg: 0.625rem;


### PR DESCRIPTION
## Description

##### Task link: N/A

Maps additional Sigil semantic color tokens (foreground-subtle ×43, border-subtle ×14, background-subtle, background-emphasized) into the Tailwind `@theme`, referencing Sigil's existing CSS variables. Additive, no rendering change; unblocks migrating the components that use these tokens.

## Test Steps
1. `bun run build` -> clean (verified).