### PR TITLE
refactor(layout): convert OrganizationSwitcher to shadcn Menu

### DIFF
--- a/src/components/layout/OrganizationSwitcher.tsx
+++ b/src/components/layout/OrganizationSwitcher.tsx
@@ -1,13 +1,15 @@
-import {
-  Button,
-  Icon,
-  Menu,
-  MenuItem,
-  MenuItemGroup,
-  MenuSeparator,
-} from "@omnidev/sigil";
 import { LuBuilding2, LuChevronDown, LuPlus, LuUser } from "react-icons/lu";
 
+import { Button } from "@/components/ui/button";
+import {
+  MenuContent,
+  MenuItem,
+  MenuItemGroup,
+  MenuPositioner,
+  MenuRoot,
+  MenuSeparator,
+  MenuTrigger,
+} from "@/components/ui/menu";
 import { AUTH_BASE_URL } from "@/lib/config/env.config";
 import { useOrganization } from "@/providers/OrganizationProvider";
 
@@ -33,47 +35,54 @@ const OrganizationSwitcher = () => {
   if (!hasMultipleOrgs) return null;
 
   return (
-    <Menu
-      trigger={
-        <Button variant="ghost" size="sm">
-          <Icon
-            src={currentOrganization.type === "personal" ? LuUser : LuBuilding2}
-          />
-          {currentOrganization.slug}
-          <Icon src={LuChevronDown} />
-        </Button>
-      }
+    <MenuRoot
       onSelect={(details) => {
         const orgId = details.value;
         if (orgId) setCurrentOrganization(orgId);
       }}
     >
-      <MenuItemGroup>
-        {organizations.map((org) => (
-          <MenuItem
-            key={org.id}
-            value={org.id}
-            disabled={org.id === currentOrganization.id}
-          >
-            <Icon src={org.type === "personal" ? LuUser : LuBuilding2} />
-            {org.slug}
-            {org.type === "personal" && " (Personal)"}
-          </MenuItem>
-        ))}
-      </MenuItemGroup>
+      <MenuTrigger asChild>
+        <Button variant="ghost" size="sm">
+          {currentOrganization.type === "personal" ? (
+            <LuUser />
+          ) : (
+            <LuBuilding2 />
+          )}
+          {currentOrganization.slug}
+          <LuChevronDown />
+        </Button>
+      </MenuTrigger>
 
-      <MenuSeparator />
+      <MenuPositioner>
+        <MenuContent>
+          <MenuItemGroup>
+            {organizations.map((org) => (
+              <MenuItem
+                key={org.id}
+                value={org.id}
+                disabled={org.id === currentOrganization.id}
+              >
+                {org.type === "personal" ? <LuUser /> : <LuBuilding2 />}
+                {org.slug}
+                {org.type === "personal" && " (Personal)"}
+              </MenuItem>
+            ))}
+          </MenuItemGroup>
 
-      {/* TODO: Implement in-app organization creation once Gatekeeper API supports it */}
-      <MenuItemGroup>
-        <MenuItem value="manage-orgs" asChild>
-          <a href={AUTH_BASE_URL}>
-            <Icon src={LuPlus} />
-            Manage Organizations
-          </a>
-        </MenuItem>
-      </MenuItemGroup>
-    </Menu>
+          <MenuSeparator />
+
+          {/* TODO: Implement in-app organization creation once Gatekeeper API supports it */}
+          <MenuItemGroup>
+            <MenuItem value="manage-orgs" asChild>
+              <a href={AUTH_BASE_URL}>
+                <LuPlus />
+                Manage Organizations
+              </a>
+            </MenuItem>
+          </MenuItemGroup>
+        </MenuContent>
+      </MenuPositioner>
+    </MenuRoot>
   );
 };
 

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -27,6 +27,8 @@
   /* Additional Sigil semantic tokens used across the app */
   --color-foreground-subtle: var(--colors-foreground-subtle);
   --color-border-subtle: var(--colors-border-subtle);
+  --color-popover: var(--colors-background-card);
+  --color-popover-foreground: var(--colors-foreground-default);
   --color-background-subtle: var(--colors-background-subtle);
   --color-background-emphasized: var(--colors-background-emphasized);
   --radius-sm: 0.375rem;


### PR DESCRIPTION
## Description

##### Task link: N/A

Converts `OrganizationSwitcher` from Sigil Menu to the shadcn Menu composition; adds `popover`/`popover-foreground` theme tokens. First real adoption of the shadcn Menu primitive. Select/disable/asChild behavior preserved.

## Test Steps
1. `bunx tsc --noEmit` clean (verified)
2. With multiple orgs, the switcher dropdown opens, lists orgs, and selecting one switches.