### PR TITLE
chore(knip): drop now-redundant ignores

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -31,17 +31,13 @@ const knipConfig: KnipConfig = {
     "src/lib/hooks/useMaxFeedbackReached.ts",
     // Server functions export public API for billing entitlements
     "src/server/functions/entitlements.ts",
-    // shadcn foundation - adoptable scaffolding, consumed as components migrate to Tailwind
-    "src/lib/utils.ts",
+    // shadcn primitives - adoptable scaffolding (the unconverted ones are tree-shaken)
     "src/components/ui/**",
   ],
   ignoreDependencies: [
     // CSS-only dependencies imported in app.css
     "tw-animate-css",
-    // Consumed by the shadcn foundation (adoptable scaffolding, see ignore list)
-    "class-variance-authority",
-    "clsx",
-    "tailwind-merge",
+    // Used only by the not-yet-adopted shadcn primitives (see ignore list)
     "lucide-react",
   ],
 };


### PR DESCRIPTION
## Description

##### Task link: N/A

Removes knip ignores that are no longer needed now that migrated components consume `cn` and the cva/clsx/tailwind-merge deps. Keeps only the not-yet-adopted shadcn primitives + lucide-react ignored.

## Test Steps
1. `bun knip` -> clean (remaining hints are pre-existing).