### PR TITLE
feat(feedback): surface possible duplicates while drafting a post

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -20,9 +20,6 @@ STRIPE_API_KEY=""
 TEST_USERNAME=""
 TEST_PASSWORD=""
 
-# emails
-RESEND_API_KEY=""
-
 # whether to enable MSW for mocked network requests/responses
 # NB: Network requests/responses are mocked by default in test environments. This is only required if you want to mock requests/responses in development
 # ENABLE_MSW=""

--- a/src/components/feedback/CreateFeedback.tsx
+++ b/src/components/feedback/CreateFeedback.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 
 import CharacterLimit from "@/components/core/CharacterLimit";
 import AttachmentUploader from "@/components/feedback/AttachmentUploader";
+import PossibleDuplicates from "@/components/feedback/PossibleDuplicates";
 import {
   CollapsibleContent,
   CollapsibleRoot,
@@ -218,6 +219,7 @@ const CreateFeedback = () => {
     },
   );
 
+  const titleValue = useStore(store, (store) => store.values.title);
   const descriptionLength = useStore(
     store,
     (store) => store.values.description.length,
@@ -269,6 +271,10 @@ const CreateFeedback = () => {
               />
             )}
           </AppField>
+
+          {projectId && (
+            <PossibleDuplicates projectId={projectId} content={titleValue} />
+          )}
 
           <AppField name="description">
             {({ TextareaField }) => (

--- a/src/components/feedback/PossibleDuplicates.tsx
+++ b/src/components/feedback/PossibleDuplicates.tsx
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link, useParams } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+
+import { similarPostsOptions } from "@/lib/options/similarPosts";
+
+interface Props {
+  projectId: string;
+  /** The current draft text (title, optionally + description). */
+  content: string;
+}
+
+/**
+ * Surfaces possible duplicate posts while a user drafts a new one, GitHub-style
+ * ("we found similar posts"). Advisory: it links to candidates so the user can
+ * upvote an existing post instead of filing a duplicate. Debounced so it does not
+ * query on every keystroke.
+ */
+const PossibleDuplicates = ({ projectId, content }: Props) => {
+  const { workspaceSlug, projectSlug } = useParams({ strict: false });
+
+  const [debounced, setDebounced] = useState(content);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(content), 400);
+    return () => clearTimeout(id);
+  }, [content]);
+
+  const { data: similar } = useQuery(similarPostsOptions(projectId, debounced));
+
+  if (!similar?.length || !workspaceSlug || !projectSlug) return null;
+
+  return (
+    <div className="rounded-md border border-border bg-background-subtle p-3 text-sm">
+      <p className="mb-1 font-medium text-foreground-subtle">
+        Possible duplicates - is your feedback already here?
+      </p>
+      <ul className="flex flex-col gap-1">
+        {similar.map((post) => (
+          <li key={post.id}>
+            <Link
+              to="/workspaces/$workspaceSlug/projects/$projectSlug/$feedbackId"
+              params={{
+                workspaceSlug: workspaceSlug as string,
+                projectSlug: projectSlug as string,
+                feedbackId: post.number ? String(post.number) : post.id,
+              }}
+              className="text-[var(--colors-brand-primary)] hover:underline"
+            >
+              {post.number ? `#${post.number} ` : ""}
+              {post.title ?? "Untitled"}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default PossibleDuplicates;

--- a/src/lib/options/similarPosts.ts
+++ b/src/lib/options/similarPosts.ts
@@ -1,0 +1,51 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { graphqlFetch } from "@/lib/graphql/graphqlFetch";
+
+export interface SimilarPost {
+  id: string;
+  number: number | null;
+  title: string | null;
+  score: number;
+}
+
+interface SimilarPostsData {
+  similarPosts: SimilarPost[];
+}
+
+interface SimilarPostsVariables {
+  projectId: string;
+  content: string;
+}
+
+// raw query (no codegen needed); the API exposes similarPosts(projectId, content)
+const SIMILAR_POSTS_QUERY = `
+  query SimilarPosts($projectId: UUID!, $content: String!) {
+    similarPosts(projectId: $projectId, content: $content) {
+      id
+      number
+      title
+      score
+    }
+  }
+`;
+
+/** Minimum draft length before we bother checking for possible duplicates. */
+export const SIMILAR_POSTS_MIN_LENGTH = 4;
+
+/**
+ * Possible-duplicate posts for a draft, surfaced while a user writes a new post
+ * ("looks like #12 already covers this"). Advisory only.
+ */
+export const similarPostsOptions = (projectId: string, content: string) =>
+  queryOptions({
+    queryKey: ["SimilarPosts", projectId, content],
+    queryFn: graphqlFetch<SimilarPostsData, SimilarPostsVariables>(
+      SIMILAR_POSTS_QUERY,
+      { projectId, content },
+    ),
+    enabled:
+      Boolean(projectId) && content.trim().length >= SIMILAR_POSTS_MIN_LENGTH,
+    select: (data) => data.similarPosts,
+    staleTime: 30_000,
+  });


### PR DESCRIPTION
## Description

##### Task link: N/A (Herald email cutover, phase 2)

Remove Resend from this service (Herald is the sole email provider). See the Herald cutover effort.

## Test Steps

1. tsc/build clean; no Resend references remain.