### PR TITLE
perf(dashboard): drop unused fields from RecentFeedback query

### DIFF
--- a/src/generated/graphql.sdk.ts
+++ b/src/generated/graphql.sdk.ts
@@ -10608,7 +10608,7 @@ export type RecentFeedbackQueryVariables = Exact<{
 }>;
 
 
-export type RecentFeedbackQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'PostEdge', node?: { __typename?: 'Post', rowId: string, number?: number | null, createdAt: Date, title?: string | null, description?: string | null, project?: { __typename?: 'Project', name: string, slug: string, organizationId: string } | null, statusTemplate?: { __typename?: 'StatusTemplate', rowId: string, displayName: string, color?: string | null } | null, user?: { __typename?: 'User', rowId: string, username?: string | null } | null } | null } | null> } | null };
+export type RecentFeedbackQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'PostEdge', node?: { __typename?: 'Post', rowId: string, number?: number | null, createdAt: Date, title?: string | null, project?: { __typename?: 'Project', name: string, slug: string, organizationId: string } | null, statusTemplate?: { __typename?: 'StatusTemplate', rowId: string, displayName: string, color?: string | null } | null } | null } | null> } | null };
 
 export type RepliesQueryVariables = Exact<{
   commentId: Scalars['UUID']['input'];
@@ -11264,7 +11264,6 @@ export const RecentFeedbackDocument = gql`
         number
         createdAt
         title
-        description
         project {
           name
           slug
@@ -11274,10 +11273,6 @@ export const RecentFeedbackDocument = gql`
           rowId
           displayName
           color
-        }
-        user {
-          rowId
-          username
         }
       }
     }

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -10607,7 +10607,7 @@ export type RecentFeedbackQueryVariables = Exact<{
 }>;
 
 
-export type RecentFeedbackQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'PostEdge', node?: { __typename?: 'Post', rowId: string, number?: number | null, createdAt: Date, title?: string | null, description?: string | null, project?: { __typename?: 'Project', name: string, slug: string, organizationId: string } | null, statusTemplate?: { __typename?: 'StatusTemplate', rowId: string, displayName: string, color?: string | null } | null, user?: { __typename?: 'User', rowId: string, username?: string | null } | null } | null } | null> } | null };
+export type RecentFeedbackQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', totalCount: number, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'PostEdge', node?: { __typename?: 'Post', rowId: string, number?: number | null, createdAt: Date, title?: string | null, project?: { __typename?: 'Project', name: string, slug: string, organizationId: string } | null, statusTemplate?: { __typename?: 'StatusTemplate', rowId: string, displayName: string, color?: string | null } | null } | null } | null> } | null };
 
 export type RepliesQueryVariables = Exact<{
   commentId: Scalars['UUID']['input'];
@@ -12298,7 +12298,6 @@ export const RecentFeedbackDocument = `
         number
         createdAt
         title
-        description
         project {
           name
           slug
@@ -12308,10 +12307,6 @@ export const RecentFeedbackDocument = `
           rowId
           displayName
           color
-        }
-        user {
-          rowId
-          username
         }
       }
     }

--- a/src/lib/graphql/queries/recentFeedback.query.graphql
+++ b/src/lib/graphql/queries/recentFeedback.query.graphql
@@ -16,7 +16,6 @@ query RecentFeedback($organizationIds: [UUID!], $after: Cursor) {
         number
         createdAt
         title
-        description
         project {
           name
           slug
@@ -26,10 +25,6 @@ query RecentFeedback($organizationIds: [UUID!], $after: Cursor) {
           rowId
           displayName
           color
-        }
-        user {
-          rowId
-          username
         }
       }
     }


### PR DESCRIPTION
## Description

##### Task link: N/A (GraphQL cost-limit remediation; follow-up to the post_reference feature deploy)

The dashboard **Recent Feedback** section lists `first: 10` posts via infinite scroll, but only renders title, status badge, project name, and relative date (`RecentFeedback.tsx` → `Response.tsx`). The query was additionally fetching `description` (large feedback HTML) and a `user { rowId username }` join that nothing in this view renders.

Dropping both trims the query's GraphQL Armor complexity cost and the per-page DB work on one of the app's hottest read paths. No rendered data changes.

**Context:** backfeed's `GRAPHQL_MAX_COMPLEXITY_COST` (1200) has been rejecting heavier reads in prod since the Feb armor→providers migration (pre-existing, not a regression). The limit is being raised separately at the infra layer; this PR reduces the dashboard read's cost so the limit can stay tight. The feedback-detail query (`FeedbackById`) is still heavy due to six *rendered* nested connections (votes/comments/tags/attachments) and would need a server-side aggregate field to trim safely — noted as a follow-up, not addressed here.

## Test Steps

1. `bun test` and `bunx tsc --noEmit` are clean.
2. Dashboard Recent Feedback renders identically (title, status, project, date) and infinite scroll still works.
3. The generated `RecentFeedbackQuery` type no longer includes `description` or `user`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)