### PR TITLE
fix(project): make tag and status empty-state CTAs clickable

### DIFF
--- a/src/components/project/ProjectTags.tsx
+++ b/src/components/project/ProjectTags.tsx
@@ -158,7 +158,15 @@ const ProjectTags = ({ projectId }: Props) => {
         </ul>
       ) : (
         <p className="text-foreground-subtle text-sm">
-          No tags yet. Create one to start categorizing feedback.
+          No tags yet.{" "}
+          <Button
+            variant="link"
+            className="h-auto p-0 align-baseline text-sm"
+            onClick={openCreate}
+          >
+            Create one
+          </Button>{" "}
+          to start categorizing feedback.
         </p>
       )}
 

--- a/src/components/project/StatusTemplateManager.tsx
+++ b/src/components/project/StatusTemplateManager.tsx
@@ -356,7 +356,15 @@ const StatusTemplateManager = () => {
         </ul>
       ) : (
         <p className="text-foreground-subtle text-sm">
-          No statuses yet. Create one to start organizing feedback.
+          No statuses yet.{" "}
+          <Button
+            variant="link"
+            className="h-auto p-0 align-baseline text-sm"
+            onClick={openCreate}
+          >
+            Create one
+          </Button>{" "}
+          to start organizing feedback.
         </p>
       )}
 


### PR DESCRIPTION
## Description

Empty-state copy implied an action (e.g. "Create one", "Add a case") but was rendered as plain, non-clickable text while the real action lived in a button elsewhere. This wires the action phrase into a live affordance using the existing handler, so users can act from where their attention already is. No behavior change beyond the new clickable target.

## Test Steps

1. Open a project's settings to the Tags section with no tags
2. Confirm "Create one" is now a link; click it and the New tag dialog opens
3. Repeat for the Statuses section empty state