### PR TITLE
fix(feedback): enable @-mentions when editing a description

### DIFF
--- a/src/components/feedback/UpdateFeedback.tsx
+++ b/src/components/feedback/UpdateFeedback.tsx
@@ -26,8 +26,10 @@ import {
 import app from "@/lib/config/app.config";
 import DEBOUNCE_TIME from "@/lib/constants/debounceTime.constant";
 import useForm from "@/lib/hooks/useForm";
+import useMentionableUsers from "@/lib/hooks/useMentionableUsers";
 import { feedbackByIdOptions } from "@/lib/options/feedback";
 import { projectIssueRefsOptions } from "@/lib/options/issueReferences";
+import { projectParticipantsOptions } from "@/lib/options/mentionableUsers";
 import toaster from "@/lib/util/toaster";
 
 import type { ComponentProps } from "react";
@@ -78,6 +80,12 @@ const UpdateFeedback = ({ feedback, triggerProps, ...rest }: Props) => {
       organizationId: feedback.project?.organizationId ?? "",
     }),
   );
+
+  // project participants, offered in the `@`-mention typeahead
+  const { data: projectParticipants } = useQuery(
+    projectParticipantsOptions({ projectId: feedback.project?.rowId }),
+  );
+  const mentionItems = useMentionableUsers(projectParticipants);
 
   const [isOpen, setIsOpen] = useState(false);
   const onClose = () => setIsOpen(false);
@@ -274,6 +282,7 @@ const UpdateFeedback = ({ feedback, triggerProps, ...rest }: Props) => {
                     }
                     editorClassName="min-h-32"
                     issueReferenceItems={issueReferenceItems}
+                    mentionItems={mentionItems}
                     // keep clicks inside the editor from reaching the card
                     onClick={(evt) => evt.stopPropagation()}
                     onUpdate={({ getHTML, getText, isEmpty }) => {


### PR DESCRIPTION
## Description

`@`-mentions worked in the **create** feedback composer but not when **editing** an existing feedback's description: `UpdateFeedback` passed `issueReferenceItems` to the rich-text editor but never `mentionItems`, so the typeahead was inert. This mirrors `CreateFeedback`: query project participants and pass the built `mentionItems` into the editor. No `ui/` component change needed (the editor already supports mentions).

## Test Steps

1. Open an existing feedback post and edit it
2. In the description, type `@` and confirm the project-participant typeahead appears
3. Select a user and confirm the mention link is inserted and persists on save