### PR TITLE
feat(feedback): inline tag editing + hide resolved statuses on the board

### DIFF
--- a/src/components/feedback/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard.tsx
@@ -13,6 +13,7 @@ import StatusBadge from "@/components/core/StatusBadge";
 import AttachmentGallery from "@/components/feedback/AttachmentGallery";
 import FeedbackKey from "@/components/feedback/FeedbackKey";
 import TagBadge from "@/components/feedback/TagBadge";
+import TagPicker from "@/components/feedback/TagPicker";
 import UpdateFeedback from "@/components/feedback/UpdateFeedback";
 import VotingButtons from "@/components/feedback/VotingButtons";
 import {
@@ -442,11 +443,32 @@ const FeedbackCard = ({
           </MenuRoot>
         </div>
 
-        {tags.length > 0 && (
+        {(tags.length > 0 ||
+          (isAuthenticated &&
+            !isFeedbackPending &&
+            feedback.project?.rowId)) && (
           <div className="flex flex-wrap items-center gap-1.5">
             {tags.map((tag) => (
               <TagBadge key={tag.rowId} name={tag.name} color={tag.color} />
             ))}
+
+            {isAuthenticated &&
+              !isFeedbackPending &&
+              feedback.rowId &&
+              feedback.project?.rowId && (
+                <TagPicker
+                  postId={feedback.rowId}
+                  projectId={feedback.project.rowId}
+                  label={compact ? "" : "Tag"}
+                  triggerProps={{
+                    variant: "ghost",
+                    size: "sm",
+                    "aria-label": "Edit tags",
+                    className:
+                      "h-6 gap-1 px-1.5 text-foreground-subtle text-xs hover:text-foreground",
+                  }}
+                />
+              )}
           </div>
         )}
 

--- a/src/components/feedback/PostTags.tsx
+++ b/src/components/feedback/PostTags.tsx
@@ -1,27 +1,9 @@
-import { Portal } from "@ark-ui/react/portal";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { LuPlus, LuX } from "react-icons/lu";
+import { LuX } from "react-icons/lu";
 
 import TagBadge from "@/components/feedback/TagBadge";
+import TagPicker from "@/components/feedback/TagPicker";
 import { Button } from "@/components/ui/button";
-import {
-  MenuContent,
-  MenuItem,
-  MenuItemGroup,
-  MenuPositioner,
-  MenuRoot,
-  MenuTrigger,
-} from "@/components/ui/menu";
-import {
-  createPostTag,
-  deletePostTag,
-  postTagsOptions,
-  postTagsQueryKey,
-  projectTagsOptions,
-} from "@/lib/options/tags";
-import toaster from "@/lib/util/toaster";
-
-import type { PostTagAssignment, PostTagsData } from "@/lib/options/tags";
+import usePostTagEditor from "@/lib/hooks/usePostTagEditor";
 
 interface Props {
   /** Post rowId tags are assigned to */
@@ -37,90 +19,13 @@ interface Props {
  * user assign or unassign tags from the project's available tags.
  */
 const PostTags = ({ postId, projectId, canAssign = false }: Props) => {
-  const queryClient = useQueryClient();
+  const { assignedTags, toggleTag } = usePostTagEditor({ postId, projectId });
 
-  const { data: assigned } = useQuery(postTagsOptions(postId));
-  const { data: projectTags } = useQuery({
-    ...projectTagsOptions(projectId),
-    enabled: canAssign && Boolean(projectId),
-  });
-
-  const queryKey = postTagsQueryKey(postId);
-
-  const invalidate = () => queryClient.invalidateQueries({ queryKey });
-
-  /** Snapshot, then apply an optimistic change to the cached post-tag list. */
-  const optimistically = async (
-    update: (nodes: PostTagAssignment[]) => PostTagAssignment[],
-  ) => {
-    await queryClient.cancelQueries({ queryKey });
-    const previous = queryClient.getQueryData<PostTagsData>(queryKey);
-    queryClient.setQueryData<PostTagsData>(queryKey, (old) =>
-      old?.post
-        ? {
-            ...old,
-            post: {
-              ...old.post,
-              postTags: {
-                ...old.post.postTags,
-                nodes: update(old.post.postTags.nodes),
-              },
-            },
-          }
-        : old,
-    );
-    return { previous };
-  };
-
-  /** Restore the snapshot taken before an optimistic change failed. */
-  const rollback = (context: { previous?: PostTagsData } | undefined) =>
-    queryClient.setQueryData(queryKey, context?.previous);
-
-  const { mutate: assignTag } = useMutation({
-    mutationFn: (tagId: string) => createPostTag({ postId, tagId }),
-    onMutate: (tagId) => {
-      const tag = (projectTags ?? []).find((t) => t.rowId === tagId);
-      return optimistically((nodes) => [
-        ...nodes,
-        {
-          rowId: "pending",
-          tag: tag
-            ? { rowId: tag.rowId, name: tag.name, color: tag.color }
-            : null,
-        },
-      ]);
-    },
-    onError: (_error, _tagId, context) => {
-      rollback(context);
-      toaster.error({ title: "Could not add tag" });
-    },
-    onSettled: invalidate,
-  });
-
-  const { mutate: unassignTag } = useMutation({
-    mutationFn: (rowId: string) => deletePostTag(rowId),
-    onMutate: (rowId) =>
-      optimistically((nodes) => nodes.filter((node) => node.rowId !== rowId)),
-    onError: (_error, _rowId, context) => {
-      rollback(context);
-      toaster.error({ title: "Could not remove tag" });
-    },
-    onSettled: invalidate,
-  });
-
-  const assignedTagIds = new Set(
-    (assigned ?? []).map((assignment) => assignment.tag?.rowId),
-  );
-
-  const availableTags = (projectTags ?? []).filter(
-    (tag) => !assignedTagIds.has(tag.rowId),
-  );
-
-  if (!canAssign && !assigned?.length) return null;
+  if (!canAssign && !assignedTags.length) return null;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      {(assigned ?? []).map((assignment) =>
+      {assignedTags.map((assignment) =>
         assignment.tag ? (
           <span key={assignment.rowId} className="inline-flex items-center">
             <TagBadge name={assignment.tag.name} color={assignment.tag.color} />
@@ -132,7 +37,7 @@ const PostTags = ({ postId, projectId, canAssign = false }: Props) => {
                 className="size-5"
                 aria-label={`Remove ${assignment.tag.name}`}
                 disabled={assignment.rowId === "pending"}
-                onClick={() => unassignTag(assignment.rowId)}
+                onClick={() => toggleTag(assignment.tag!.rowId)}
               >
                 <LuX className="size-3" />
               </Button>
@@ -141,33 +46,7 @@ const PostTags = ({ postId, projectId, canAssign = false }: Props) => {
         ) : null,
       )}
 
-      {canAssign && availableTags.length > 0 && (
-        <MenuRoot
-          positioning={{ placement: "bottom-start" }}
-          onSelect={({ value }) => assignTag(value)}
-        >
-          <MenuTrigger asChild>
-            <Button size="sm" variant="outline">
-              <LuPlus className="size-4" />
-              Add tag
-            </Button>
-          </MenuTrigger>
-
-          <Portal>
-            <MenuPositioner>
-              <MenuContent>
-                <MenuItemGroup>
-                  {availableTags.map((tag) => (
-                    <MenuItem key={tag.rowId} value={tag.rowId}>
-                      <TagBadge name={tag.name} color={tag.color} />
-                    </MenuItem>
-                  ))}
-                </MenuItemGroup>
-              </MenuContent>
-            </MenuPositioner>
-          </Portal>
-        </MenuRoot>
-      )}
+      {canAssign && <TagPicker postId={postId} projectId={projectId} />}
     </div>
   );
 };

--- a/src/components/feedback/TagPicker.tsx
+++ b/src/components/feedback/TagPicker.tsx
@@ -1,0 +1,158 @@
+import {
+  Combobox as ArkCombobox,
+  createListCollection,
+} from "@ark-ui/react/combobox";
+import { Portal } from "@ark-ui/react/portal";
+import { useMemo, useState } from "react";
+import { LuCheck, LuPlus } from "react-icons/lu";
+
+import { Button } from "@/components/ui/button";
+import usePostTagEditor from "@/lib/hooks/usePostTagEditor";
+
+import type { ComponentProps } from "react";
+
+/** Default chip color when a tag has no color set (mirrors TagBadge). */
+const DEFAULT_COLOR = "#94a3b8";
+
+interface Props {
+  /** Post rowId tags are assigned to. */
+  postId: string;
+  /** Project rowId the post belongs to (source of available tags). */
+  projectId: string;
+  /** Trigger button label. */
+  label?: string;
+  /** Props forwarded to the trigger button (size, variant, className, etc). */
+  triggerProps?: ComponentProps<typeof Button>;
+}
+
+/**
+ * Tag picker. A searchable, multi-select popover for assigning a post's tags.
+ * Stays open while toggling so several tags can be set at once, and reflects
+ * each change instantly across every surface the post appears on.
+ */
+const TagPicker = ({
+  postId,
+  projectId,
+  label = "Add tag",
+  triggerProps,
+}: Props) => {
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+
+  // defer loading the tag queries until the picker is first opened so a long
+  // feedback list does not fire a query per card
+  const [hasOpened, setHasOpened] = useState(false);
+
+  const { projectTags, assignedTagIds, toggleTag } = usePostTagEditor({
+    postId,
+    projectId,
+    enabled: hasOpened,
+  });
+
+  const filteredTags = useMemo(() => {
+    const needle = inputValue.trim().toLowerCase();
+    return needle
+      ? projectTags.filter((tag) => tag.name.toLowerCase().includes(needle))
+      : projectTags;
+  }, [projectTags, inputValue]);
+
+  const collection = useMemo(
+    () =>
+      createListCollection({
+        items: filteredTags.map((tag) => ({
+          label: tag.name,
+          value: tag.rowId,
+        })),
+      }),
+    [filteredTags],
+  );
+
+  return (
+    <ArkCombobox.Root
+      collection={collection}
+      open={open}
+      onOpenChange={({ open }) => {
+        if (open) setHasOpened(true);
+        setOpen(open);
+      }}
+      value={assignedTagIds}
+      onValueChange={({ value }) => {
+        // multi-select toggles one item per interaction; find the one that
+        // flipped and run the matching assign/unassign
+        const added = value.find((id) => !assignedTagIds.includes(id));
+        const removed = assignedTagIds.find((id) => !value.includes(id));
+        const toggled = added ?? removed;
+        if (toggled) toggleTag(toggled);
+      }}
+      inputValue={inputValue}
+      onInputValueChange={({ inputValue }) => setInputValue(inputValue)}
+      multiple
+      closeOnSelect={false}
+      selectionBehavior="preserve"
+      loopFocus
+    >
+      <ArkCombobox.Trigger asChild>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={(evt) => evt.stopPropagation()}
+          {...triggerProps}
+        >
+          <LuPlus className="size-4" />
+          {label}
+        </Button>
+      </ArkCombobox.Trigger>
+
+      <Portal>
+        <ArkCombobox.Positioner>
+          <ArkCombobox.Content
+            className="z-50 w-56 rounded-lg border border-border bg-popover p-1 shadow-md"
+            onClick={(evt) => evt.stopPropagation()}
+          >
+            <ArkCombobox.Input
+              autoFocus
+              placeholder="Search tags..."
+              className="mb-1 w-full rounded-md border border-input bg-muted px-2 py-1.5 text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+
+            <div className="max-h-60 overflow-y-auto">
+              {filteredTags.map((tag) => (
+                <ArkCombobox.Item
+                  key={tag.rowId}
+                  item={{ label: tag.name, value: tag.rowId }}
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-popover-foreground text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                >
+                  <span
+                    aria-hidden
+                    className="size-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: tag.color || DEFAULT_COLOR }}
+                  />
+                  <ArkCombobox.ItemText className="flex-1 truncate">
+                    {tag.name}
+                  </ArkCombobox.ItemText>
+                  <ArkCombobox.ItemIndicator>
+                    <LuCheck className="size-4 text-[var(--colors-green-500)]" />
+                  </ArkCombobox.ItemIndicator>
+                </ArkCombobox.Item>
+              ))}
+
+              {!projectTags.length && (
+                <p className="px-2 py-4 text-center text-muted-foreground text-sm">
+                  No tags yet
+                </p>
+              )}
+
+              {!!projectTags.length && !filteredTags.length && (
+                <p className="px-2 py-4 text-center text-muted-foreground text-sm">
+                  No matches
+                </p>
+              )}
+            </div>
+          </ArkCombobox.Content>
+        </ArkCombobox.Positioner>
+      </Portal>
+    </ArkCombobox.Root>
+  );
+};
+
+export default TagPicker;

--- a/src/components/feedback/UpdateFeedback.tsx
+++ b/src/components/feedback/UpdateFeedback.tsx
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 import CharacterLimit from "@/components/core/CharacterLimit";
 import AttachmentUploader from "@/components/feedback/AttachmentUploader";
+import PostTags from "@/components/feedback/PostTags";
 import { Button } from "@/components/ui/button";
 import {
   DialogBackdrop,
@@ -293,6 +294,21 @@ const UpdateFeedback = ({ feedback, triggerProps, ...rest }: Props) => {
                 </div>
               )}
             </AppField>
+
+            {/* mount only while open so closed cards don't each fetch tags */}
+            {isOpen &&
+              feedback.rowId &&
+              feedback.rowId !== "pending" &&
+              feedback.project?.rowId && (
+                <div className="flex flex-col gap-1.5">
+                  <Label>{app.projectPage.projectFeedback.tags.label}</Label>
+                  <PostTags
+                    postId={feedback.rowId}
+                    projectId={feedback.project.rowId}
+                    canAssign
+                  />
+                </div>
+              )}
 
             {!!existingAttachments.length && (
               <div className="grid grid-cols-4 gap-2 sm:grid-cols-6">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,4 +1,9 @@
-import { FaDiscord, FaGithub, FaXTwitter as FaX } from "react-icons/fa6";
+import {
+  FaDiscord,
+  FaGithub,
+  FaThreads,
+  FaXTwitter as FaX,
+} from "react-icons/fa6";
 
 import app from "@/lib/config/app.config";
 
@@ -71,6 +76,15 @@ const Footer = () => (
           className={linkClass}
         >
           <FaX className="size-4" />
+        </a>
+
+        <a
+          href={app.socials.threads}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={linkClass}
+        >
+          <FaThreads className="size-5" />
         </a>
       </div>
     </div>

--- a/src/components/project/StatusTemplateManager.tsx
+++ b/src/components/project/StatusTemplateManager.tsx
@@ -34,6 +34,7 @@ import {
   useDeleteStatusTemplateMutation,
   useUpdateStatusTemplateMutation,
 } from "@/generated/graphql";
+import { isStatusOnBoard } from "@/lib/constants/board.constant";
 import { isStatusOnRoadmap } from "@/lib/constants/roadmap.constant";
 import { projectStatusesOptions } from "@/lib/options/projects";
 import slugify from "@/lib/util/slugify";
@@ -65,6 +66,7 @@ interface Status {
   color?: string | null;
   sortOrder?: number | null;
   showOnRoadmap?: boolean | null;
+  showOnBoard?: boolean | null;
 }
 
 /**
@@ -218,6 +220,48 @@ const StatusTemplateManager = () => {
     onSettled: invalidate,
   });
 
+  const { mutate: toggleBoard } = useMutation({
+    mutationFn: ({
+      rowId,
+      showOnBoard,
+    }: {
+      rowId: string;
+      showOnBoard: boolean;
+    }) => updateStatus({ rowId, patch: { showOnBoard } }),
+    // optimistically flip the switch so it responds instantly, then reconcile
+    onMutate: async ({ rowId, showOnBoard }) => {
+      await queryClient.cancelQueries({ queryKey: statusesOptions.queryKey });
+      const previous = queryClient.getQueryData<ProjectStatusesQuery>(
+        statusesOptions.queryKey,
+      );
+
+      queryClient.setQueryData<ProjectStatusesQuery>(
+        statusesOptions.queryKey,
+        (old) =>
+          old?.statusTemplates?.nodes
+            ? {
+                ...old,
+                statusTemplates: {
+                  ...old.statusTemplates,
+                  nodes: old.statusTemplates.nodes.map((node) =>
+                    node?.rowId === rowId ? { ...node, showOnBoard } : node,
+                  ),
+                },
+              }
+            : old,
+      );
+
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(statusesOptions.queryKey, context.previous);
+      }
+      toaster.error({ title: "Could not update board visibility" });
+    },
+    onSettled: invalidate,
+  });
+
   // swap a status with its neighbor by exchanging sort orders
   const { mutate: reorder } = useMutation({
     mutationFn: async ({
@@ -291,6 +335,28 @@ const StatusTemplateManager = () => {
               </div>
 
               <div className="flex shrink-0 items-center gap-1">
+                <span className="mr-1 flex items-center gap-1.5 text-foreground-subtle text-xs">
+                  <span className="hidden sm:inline">Board</span>
+                  <SwitchRoot
+                    aria-label={`Show ${status.displayName} on the board by default`}
+                    checked={isStatusOnBoard({
+                      name: status.name,
+                      showOnBoard: status.showOnBoard,
+                    })}
+                    onCheckedChange={({ checked }) =>
+                      toggleBoard({
+                        rowId: status.rowId,
+                        showOnBoard: checked,
+                      })
+                    }
+                  >
+                    <SwitchControl>
+                      <SwitchThumb />
+                    </SwitchControl>
+                    <SwitchHiddenInput />
+                  </SwitchRoot>
+                </span>
+
                 <span className="mr-1 flex items-center gap-1.5 text-foreground-subtle text-xs">
                   <span className="hidden sm:inline">Roadmap</span>
                   <SwitchRoot

--- a/src/generated/graphql.sdk.ts
+++ b/src/generated/graphql.sdk.ts
@@ -7450,6 +7450,7 @@ export type StatusTemplate = {
   /** Reads and enables pagination through a set of `ProjectStatusConfig`. */
   projectStatusConfigs: ProjectStatusConfigConnection;
   rowId: Scalars['UUID']['output'];
+  showOnBoard?: Maybe<Scalars['Boolean']['output']>;
   showOnRoadmap?: Maybe<Scalars['Boolean']['output']>;
   sortOrder?: Maybe<Scalars['Int']['output']>;
   updatedAt: Scalars['Datetime']['output'];
@@ -7541,6 +7542,8 @@ export type StatusTemplateCondition = {
   organizationId?: InputMaybe<Scalars['UUID']['input']>;
   /** Checks for equality with the object’s `rowId` field. */
   rowId?: InputMaybe<Scalars['UUID']['input']>;
+  /** Checks for equality with the object’s `showOnBoard` field. */
+  showOnBoard?: InputMaybe<Scalars['Boolean']['input']>;
   /** Checks for equality with the object’s `showOnRoadmap` field. */
   showOnRoadmap?: InputMaybe<Scalars['Boolean']['input']>;
   /** Checks for equality with the object’s `sortOrder` field. */
@@ -7591,6 +7594,8 @@ export type StatusTemplateDistinctCountAggregates = {
   organizationId?: Maybe<Scalars['BigInt']['output']>;
   /** Distinct count of rowId across the matching connection */
   rowId?: Maybe<Scalars['BigInt']['output']>;
+  /** Distinct count of showOnBoard across the matching connection */
+  showOnBoard?: Maybe<Scalars['BigInt']['output']>;
   /** Distinct count of showOnRoadmap across the matching connection */
   showOnRoadmap?: Maybe<Scalars['BigInt']['output']>;
   /** Distinct count of sortOrder across the matching connection */
@@ -7644,6 +7649,8 @@ export type StatusTemplateFilter = {
   projectStatusConfigsExist?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter by the object’s `rowId` field. */
   rowId?: InputMaybe<UuidFilter>;
+  /** Filter by the object’s `showOnBoard` field. */
+  showOnBoard?: InputMaybe<BooleanFilter>;
   /** Filter by the object’s `showOnRoadmap` field. */
   showOnRoadmap?: InputMaybe<BooleanFilter>;
   /** Filter by the object’s `sortOrder` field. */
@@ -7663,6 +7670,7 @@ export enum StatusTemplateGroupBy {
   KeywordRole = 'KEYWORD_ROLE',
   Name = 'NAME',
   OrganizationId = 'ORGANIZATION_ID',
+  ShowOnBoard = 'SHOW_ON_BOARD',
   ShowOnRoadmap = 'SHOW_ON_ROADMAP',
   SortOrder = 'SORT_ORDER',
   UpdatedAt = 'UPDATED_AT',
@@ -7749,6 +7757,7 @@ export type StatusTemplateInput = {
   name: Scalars['String']['input'];
   organizationId: Scalars['UUID']['input'];
   rowId?: InputMaybe<Scalars['UUID']['input']>;
+  showOnBoard?: InputMaybe<Scalars['Boolean']['input']>;
   showOnRoadmap?: InputMaybe<Scalars['Boolean']['input']>;
   sortOrder?: InputMaybe<Scalars['Int']['input']>;
   updatedAt?: InputMaybe<Scalars['Datetime']['input']>;
@@ -7887,6 +7896,8 @@ export enum StatusTemplateOrderBy {
   ProjectStatusConfigsVarianceSampleSortOrderDesc = 'PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_DESC',
   RowIdAsc = 'ROW_ID_ASC',
   RowIdDesc = 'ROW_ID_DESC',
+  ShowOnBoardAsc = 'SHOW_ON_BOARD_ASC',
+  ShowOnBoardDesc = 'SHOW_ON_BOARD_DESC',
   ShowOnRoadmapAsc = 'SHOW_ON_ROADMAP_ASC',
   ShowOnRoadmapDesc = 'SHOW_ON_ROADMAP_DESC',
   SortOrderAsc = 'SORT_ORDER_ASC',
@@ -7905,6 +7916,7 @@ export type StatusTemplatePatch = {
   name?: InputMaybe<Scalars['String']['input']>;
   organizationId?: InputMaybe<Scalars['UUID']['input']>;
   rowId?: InputMaybe<Scalars['UUID']['input']>;
+  showOnBoard?: InputMaybe<Scalars['Boolean']['input']>;
   showOnRoadmap?: InputMaybe<Scalars['Boolean']['input']>;
   sortOrder?: InputMaybe<Scalars['Int']['input']>;
   updatedAt?: InputMaybe<Scalars['Datetime']['input']>;
@@ -10439,7 +10451,7 @@ export type UpdateStatusTemplateMutationVariables = Exact<{
 }>;
 
 
-export type UpdateStatusTemplateMutation = { __typename?: 'Mutation', updateStatusTemplate?: { __typename?: 'UpdateStatusTemplatePayload', clientMutationId?: string | null, statusTemplate?: { __typename?: 'StatusTemplate', rowId: string, name: string, displayName: string, color?: string | null, description?: string | null, sortOrder?: number | null, showOnRoadmap?: boolean | null } | null } | null };
+export type UpdateStatusTemplateMutation = { __typename?: 'Mutation', updateStatusTemplate?: { __typename?: 'UpdateStatusTemplatePayload', clientMutationId?: string | null, statusTemplate?: { __typename?: 'StatusTemplate', rowId: string, name: string, displayName: string, color?: string | null, description?: string | null, sortOrder?: number | null, showOnRoadmap?: boolean | null, showOnBoard?: boolean | null } | null } | null };
 
 export type CreateUserMutationVariables = Exact<{
   identityProviderId: Scalars['UUID']['input'];
@@ -10574,7 +10586,7 @@ export type ProjectStatusesQueryVariables = Exact<{
 }>;
 
 
-export type ProjectStatusesQuery = { __typename?: 'Query', statusTemplates?: { __typename?: 'StatusTemplateConnection', nodes: Array<{ __typename?: 'StatusTemplate', rowId: string, name: string, displayName: string, description?: string | null, color?: string | null, sortOrder?: number | null, showOnRoadmap?: boolean | null } | null> } | null, projectStatusConfigs?: { __typename?: 'ProjectStatusConfigConnection', nodes: Array<{ __typename?: 'ProjectStatusConfig', rowId: string, projectId: string, statusTemplateId: string, customColor?: string | null, customDescription?: string | null, isEnabled?: boolean | null, isDefault?: boolean | null, sortOrder?: number | null } | null> } | null };
+export type ProjectStatusesQuery = { __typename?: 'Query', statusTemplates?: { __typename?: 'StatusTemplateConnection', nodes: Array<{ __typename?: 'StatusTemplate', rowId: string, name: string, displayName: string, description?: string | null, color?: string | null, sortOrder?: number | null, showOnRoadmap?: boolean | null, showOnBoard?: boolean | null } | null> } | null, projectStatusConfigs?: { __typename?: 'ProjectStatusConfigConnection', nodes: Array<{ __typename?: 'ProjectStatusConfig', rowId: string, projectId: string, statusTemplateId: string, customColor?: string | null, customDescription?: string | null, isEnabled?: boolean | null, isDefault?: boolean | null, sortOrder?: number | null } | null> } | null };
 
 export type ProjectsQueryVariables = Exact<{
   pageSize: Scalars['Int']['input'];
@@ -10976,6 +10988,7 @@ export const UpdateStatusTemplateDocument = gql`
       description
       sortOrder
       showOnRoadmap
+      showOnBoard
     }
   }
 }
@@ -11187,6 +11200,7 @@ export const ProjectStatusesDocument = gql`
       color
       sortOrder
       showOnRoadmap
+      showOnBoard
     }
   }
   projectStatusConfigs(condition: {isEnabled: $isEnabled}) {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -7449,6 +7449,7 @@ export type StatusTemplate = {
   /** Reads and enables pagination through a set of `ProjectStatusConfig`. */
   projectStatusConfigs: ProjectStatusConfigConnection;
   rowId: Scalars['UUID']['output'];
+  showOnBoard?: Maybe<Scalars['Boolean']['output']>;
   showOnRoadmap?: Maybe<Scalars['Boolean']['output']>;
   sortOrder?: Maybe<Scalars['Int']['output']>;
   updatedAt: Scalars['Datetime']['output'];
@@ -7540,6 +7541,8 @@ export type StatusTemplateCondition = {
   organizationId?: InputMaybe<Scalars['UUID']['input']>;
   /** Checks for equality with the object’s `rowId` field. */
   rowId?: InputMaybe<Scalars['UUID']['input']>;
+  /** Checks for equality with the object’s `showOnBoard` field. */
+  showOnBoard?: InputMaybe<Scalars['Boolean']['input']>;
   /** Checks for equality with the object’s `showOnRoadmap` field. */
   showOnRoadmap?: InputMaybe<Scalars['Boolean']['input']>;
   /** Checks for equality with the object’s `sortOrder` field. */
@@ -7590,6 +7593,8 @@ export type StatusTemplateDistinctCountAggregates = {
   organizationId?: Maybe<Scalars['BigInt']['output']>;
   /** Distinct count of rowId across the matching connection */
   rowId?: Maybe<Scalars['BigInt']['output']>;
+  /** Distinct count of showOnBoard across the matching connection */
+  showOnBoard?: Maybe<Scalars['BigInt']['output']>;
   /** Distinct count of showOnRoadmap across the matching connection */
   showOnRoadmap?: Maybe<Scalars['BigInt']['output']>;
   /** Distinct count of sortOrder across the matching connection */
@@ -7643,6 +7648,8 @@ export type StatusTemplateFilter = {
   projectStatusConfigsExist?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter by the object’s `rowId` field. */
   rowId?: InputMaybe<UuidFilter>;
+  /** Filter by the object’s `showOnBoard` field. */
+  showOnBoard?: InputMaybe<BooleanFilter>;
   /** Filter by the object’s `showOnRoadmap` field. */
   showOnRoadmap?: InputMaybe<BooleanFilter>;
   /** Filter by the object’s `sortOrder` field. */
@@ -7662,6 +7669,7 @@ export enum StatusTemplateGroupBy {
   KeywordRole = 'KEYWORD_ROLE',
   Name = 'NAME',
   OrganizationId = 'ORGANIZATION_ID',
+  ShowOnBoard = 'SHOW_ON_BOARD',
   ShowOnRoadmap = 'SHOW_ON_ROADMAP',
   SortOrder = 'SORT_ORDER',
   UpdatedAt = 'UPDATED_AT',
@@ -7748,6 +7756,7 @@ export type StatusTemplateInput = {
   name: Scalars['String']['input'];
   organizationId: Scalars['UUID']['input'];
   rowId?: InputMaybe<Scalars['UUID']['input']>;
+  showOnBoard?: InputMaybe<Scalars['Boolean']['input']>;
   showOnRoadmap?: InputMaybe<Scalars['Boolean']['input']>;
   sortOrder?: InputMaybe<Scalars['Int']['input']>;
   updatedAt?: InputMaybe<Scalars['Datetime']['input']>;
@@ -7886,6 +7895,8 @@ export enum StatusTemplateOrderBy {
   ProjectStatusConfigsVarianceSampleSortOrderDesc = 'PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_DESC',
   RowIdAsc = 'ROW_ID_ASC',
   RowIdDesc = 'ROW_ID_DESC',
+  ShowOnBoardAsc = 'SHOW_ON_BOARD_ASC',
+  ShowOnBoardDesc = 'SHOW_ON_BOARD_DESC',
   ShowOnRoadmapAsc = 'SHOW_ON_ROADMAP_ASC',
   ShowOnRoadmapDesc = 'SHOW_ON_ROADMAP_DESC',
   SortOrderAsc = 'SORT_ORDER_ASC',
@@ -7904,6 +7915,7 @@ export type StatusTemplatePatch = {
   name?: InputMaybe<Scalars['String']['input']>;
   organizationId?: InputMaybe<Scalars['UUID']['input']>;
   rowId?: InputMaybe<Scalars['UUID']['input']>;
+  showOnBoard?: InputMaybe<Scalars['Boolean']['input']>;
   showOnRoadmap?: InputMaybe<Scalars['Boolean']['input']>;
   sortOrder?: InputMaybe<Scalars['Int']['input']>;
   updatedAt?: InputMaybe<Scalars['Datetime']['input']>;
@@ -10438,7 +10450,7 @@ export type UpdateStatusTemplateMutationVariables = Exact<{
 }>;
 
 
-export type UpdateStatusTemplateMutation = { __typename?: 'Mutation', updateStatusTemplate?: { __typename?: 'UpdateStatusTemplatePayload', clientMutationId?: string | null, statusTemplate?: { __typename?: 'StatusTemplate', rowId: string, name: string, displayName: string, color?: string | null, description?: string | null, sortOrder?: number | null, showOnRoadmap?: boolean | null } | null } | null };
+export type UpdateStatusTemplateMutation = { __typename?: 'Mutation', updateStatusTemplate?: { __typename?: 'UpdateStatusTemplatePayload', clientMutationId?: string | null, statusTemplate?: { __typename?: 'StatusTemplate', rowId: string, name: string, displayName: string, color?: string | null, description?: string | null, sortOrder?: number | null, showOnRoadmap?: boolean | null, showOnBoard?: boolean | null } | null } | null };
 
 export type CreateUserMutationVariables = Exact<{
   identityProviderId: Scalars['UUID']['input'];
@@ -10573,7 +10585,7 @@ export type ProjectStatusesQueryVariables = Exact<{
 }>;
 
 
-export type ProjectStatusesQuery = { __typename?: 'Query', statusTemplates?: { __typename?: 'StatusTemplateConnection', nodes: Array<{ __typename?: 'StatusTemplate', rowId: string, name: string, displayName: string, description?: string | null, color?: string | null, sortOrder?: number | null, showOnRoadmap?: boolean | null } | null> } | null, projectStatusConfigs?: { __typename?: 'ProjectStatusConfigConnection', nodes: Array<{ __typename?: 'ProjectStatusConfig', rowId: string, projectId: string, statusTemplateId: string, customColor?: string | null, customDescription?: string | null, isEnabled?: boolean | null, isDefault?: boolean | null, sortOrder?: number | null } | null> } | null };
+export type ProjectStatusesQuery = { __typename?: 'Query', statusTemplates?: { __typename?: 'StatusTemplateConnection', nodes: Array<{ __typename?: 'StatusTemplate', rowId: string, name: string, displayName: string, description?: string | null, color?: string | null, sortOrder?: number | null, showOnRoadmap?: boolean | null, showOnBoard?: boolean | null } | null> } | null, projectStatusConfigs?: { __typename?: 'ProjectStatusConfigConnection', nodes: Array<{ __typename?: 'ProjectStatusConfig', rowId: string, projectId: string, statusTemplateId: string, customColor?: string | null, customDescription?: string | null, isEnabled?: boolean | null, isDefault?: boolean | null, sortOrder?: number | null } | null> } | null };
 
 export type ProjectsQueryVariables = Exact<{
   pageSize: Scalars['Int']['input'];
@@ -11337,6 +11349,7 @@ export const UpdateStatusTemplateDocument = `
       description
       sortOrder
       showOnRoadmap
+      showOnBoard
     }
   }
 }
@@ -12135,6 +12148,7 @@ export const ProjectStatusesDocument = `
       color
       sortOrder
       showOnRoadmap
+      showOnBoard
     }
   }
   projectStatusConfigs(condition: {isEnabled: $isEnabled}) {

--- a/src/lib/config/app.config.ts
+++ b/src/lib/config/app.config.ts
@@ -896,6 +896,9 @@ const app = {
           plural: "Sort By",
         },
       },
+      tags: {
+        label: "Tags",
+      },
       feedbackTitle: {
         label: "Title",
         placeholders: [

--- a/src/lib/config/app.config.ts
+++ b/src/lib/config/app.config.ts
@@ -13,6 +13,7 @@ const app = {
     discord: "https://discord.gg/omnidotdev",
     github: "https://github.com/omnidotdev/backfeed-stack",
     x: "https://x.com/omnidotdev",
+    threads: "https://www.threads.com/@omnidotdev",
   },
   organization: {
     name: "Omni",

--- a/src/lib/constants/__tests__/board.test.ts
+++ b/src/lib/constants/__tests__/board.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+
+import { BOARD_HIDDEN_STATUS_NAMES, isStatusOnBoard } from "../board.constant";
+
+describe("isStatusOnBoard", () => {
+  it("hides terminal statuses by the default heuristic", () => {
+    for (const name of BOARD_HIDDEN_STATUS_NAMES) {
+      expect(isStatusOnBoard({ name })).toBe(false);
+    }
+  });
+
+  it("shows active statuses by the default heuristic", () => {
+    expect(isStatusOnBoard({ name: "open" })).toBe(true);
+    expect(isStatusOnBoard({ name: "under_review" })).toBe(true);
+    expect(isStatusOnBoard({ name: "in_progress" })).toBe(true);
+    expect(isStatusOnBoard({ name: "planned" })).toBe(true);
+  });
+
+  it("shows unknown custom statuses by default", () => {
+    expect(isStatusOnBoard({ name: "needs_triage" })).toBe(true);
+    expect(isStatusOnBoard({ name: undefined })).toBe(true);
+    expect(isStatusOnBoard({})).toBe(true);
+  });
+
+  it("lets an explicit flag override the heuristic in both directions", () => {
+    // force a normally-hidden status onto the board
+    expect(isStatusOnBoard({ name: "completed", showOnBoard: true })).toBe(
+      true,
+    );
+    // hide a normally-shown status from the board
+    expect(isStatusOnBoard({ name: "open", showOnBoard: false })).toBe(false);
+  });
+
+  it("falls back to the heuristic when the flag is null", () => {
+    expect(isStatusOnBoard({ name: "completed", showOnBoard: null })).toBe(
+      false,
+    );
+    expect(isStatusOnBoard({ name: "open", showOnBoard: null })).toBe(true);
+  });
+});

--- a/src/lib/constants/board.constant.ts
+++ b/src/lib/constants/board.constant.ts
@@ -1,0 +1,24 @@
+/**
+ * Status `name`s hidden from the board by default. The board is the active
+ * working view (Open / Under Review / In Progress / Planned), so terminal
+ * statuses (Completed / Closed) are filtered out by default to keep resolved
+ * items from burying open feedback. The pills stay one click away, so anyone
+ * can toggle a hidden status back on.
+ *
+ * Matches the seeded default status names; custom statuses fall through and are
+ * shown. The per-status `showOnBoard` flag overrides this heuristic.
+ */
+export const BOARD_HIDDEN_STATUS_NAMES = new Set<string>([
+  "completed",
+  "closed",
+]);
+
+/**
+ * Whether a status is shown on the board by default: the explicit `showOnBoard`
+ * flag if an admin set one, otherwise the default curation heuristic.
+ */
+export const isStatusOnBoard = (status: {
+  name?: string | null;
+  showOnBoard?: boolean | null;
+}): boolean =>
+  status.showOnBoard ?? !BOARD_HIDDEN_STATUS_NAMES.has(status.name ?? "");

--- a/src/lib/graphql/mutations/statusTemplate/updateStatusTemplate.mutation.graphql
+++ b/src/lib/graphql/mutations/statusTemplate/updateStatusTemplate.mutation.graphql
@@ -9,6 +9,7 @@ mutation UpdateStatusTemplate($rowId: UUID!, $patch: StatusTemplatePatch!) {
       description
       sortOrder
       showOnRoadmap
+      showOnBoard
     }
   }
 }

--- a/src/lib/graphql/queries/projectStatuses.query.graphql
+++ b/src/lib/graphql/queries/projectStatuses.query.graphql
@@ -11,6 +11,7 @@ query ProjectStatuses($organizationId: UUID!, $isEnabled: Boolean) {
       color
       sortOrder
       showOnRoadmap
+      showOnBoard
     }
   }
   projectStatusConfigs(condition: { isEnabled: $isEnabled }) {

--- a/src/lib/hooks/usePostTagEditor.ts
+++ b/src/lib/hooks/usePostTagEditor.ts
@@ -1,0 +1,191 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createPostTag,
+  deletePostTag,
+  postTagsOptions,
+  postTagsQueryKey,
+  projectTagsOptions,
+} from "@/lib/options/tags";
+import toaster from "@/lib/util/toaster";
+
+import type { InfiniteData } from "@tanstack/react-query";
+import type { PostTagAssignment, PostTagsData, Tag } from "@/lib/options/tags";
+
+/** A post node carrying the tag list shape shared by every feedback query. */
+interface PostTagsNode {
+  rowId: string;
+  postTags: {
+    nodes: Array<{ tag: Pick<Tag, "rowId" | "name" | "color"> | null } | null>;
+  };
+}
+
+interface Params {
+  /** Post rowId tags are assigned to. */
+  postId: string;
+  /** Project rowId the post belongs to (source of available tags). */
+  projectId: string;
+  /** Load the queries. Defer until a picker is actually opened to avoid a query per card. */
+  enabled?: boolean;
+}
+
+/**
+ * Shared logic for assigning and unassigning a post's tags. Keeps every cache
+ * that renders the post (detail page, feedback lists, roadmap board) in sync
+ * with a single optimistic toggle, so a change made on one surface shows
+ * instantly on all of them.
+ */
+const usePostTagEditor = ({ postId, projectId, enabled = true }: Params) => {
+  const queryClient = useQueryClient();
+
+  const { data: assignedTags, isLoading: isLoadingAssigned } = useQuery({
+    ...postTagsOptions(postId),
+    enabled: enabled && Boolean(postId),
+  });
+  const { data: projectTags, isLoading: isLoadingProjectTags } = useQuery({
+    ...projectTagsOptions(projectId),
+    enabled: enabled && Boolean(projectId),
+  });
+
+  const queryKey = postTagsQueryKey(postId);
+
+  /** Apply the same tag-list edit to every cached copy of this post. */
+  const patchEverySurface = (
+    edit: (
+      nodes: PostTagsNode["postTags"]["nodes"],
+    ) => PostTagsNode["postTags"]["nodes"],
+  ) => {
+    const patchPost = <T extends PostTagsNode | null | undefined>(
+      post: T,
+    ): T =>
+      post && post.rowId === postId
+        ? {
+            ...post,
+            postTags: { ...post.postTags, nodes: edit(post.postTags.nodes) },
+          }
+        : post;
+
+    // detail page + the picker itself
+    queryClient.setQueryData<PostTagsData>(queryKey, (old) =>
+      old?.post ? { ...old, post: patchPost(old.post) } : old,
+    );
+
+    // single-post detail queries
+    for (const key of [["FeedbackById"], ["FeedbackByNumber"]] as const) {
+      queryClient.setQueriesData<{ post?: PostTagsNode | null } | undefined>(
+        { queryKey: key },
+        (old) => (old ? { ...old, post: patchPost(old.post) } : old),
+      );
+      queryClient.setQueriesData<
+        { postByProjectIdAndNumber?: PostTagsNode | null } | undefined
+      >({ queryKey: key }, (old) =>
+        old?.postByProjectIdAndNumber
+          ? {
+              ...old,
+              postByProjectIdAndNumber: patchPost(old.postByProjectIdAndNumber),
+            }
+          : old,
+      );
+    }
+
+    // every paginated feedback list (project feed, grid, roadmap columns)
+    queryClient.setQueriesData<
+      InfiniteData<{ posts?: { nodes: Array<PostTagsNode | null> } | null }>
+    >({ queryKey: ["Posts.infinite"] }, (old) =>
+      old
+        ? {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              posts: page.posts
+                ? {
+                    ...page.posts,
+                    nodes: page.posts.nodes.map((node) => patchPost(node)),
+                  }
+                : page.posts,
+            })),
+          }
+        : old,
+    );
+  };
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey });
+    queryClient.invalidateQueries({ queryKey: ["Posts.infinite"] });
+    queryClient.invalidateQueries({ queryKey: ["FeedbackById"] });
+    queryClient.invalidateQueries({ queryKey: ["FeedbackByNumber"] });
+  };
+
+  /** Snapshot the detail-page cache so a failed mutation can roll back. */
+  const snapshot = async () => {
+    await queryClient.cancelQueries({ queryKey });
+    return queryClient.getQueryData<PostTagsData>(queryKey);
+  };
+
+  const { mutate: assign } = useMutation({
+    mutationFn: (tagId: string) => createPostTag({ postId, tagId }),
+    onMutate: async (tagId) => {
+      const previous = await snapshot();
+      const tag = (projectTags ?? []).find((t) => t.rowId === tagId);
+      patchEverySurface((nodes) => [
+        ...nodes,
+        {
+          tag: tag
+            ? { rowId: tag.rowId, name: tag.name, color: tag.color }
+            : null,
+        },
+      ]);
+      return { previous };
+    },
+    onError: (_error, _tagId, context) => {
+      queryClient.setQueryData(queryKey, context?.previous);
+      invalidate();
+      toaster.error({ title: "Could not add tag" });
+    },
+    onSettled: invalidate,
+  });
+
+  const { mutate: unassign } = useMutation({
+    mutationFn: (tagId: string) => {
+      const assignment = (assignedTags ?? []).find(
+        (node) => node.tag?.rowId === tagId,
+      );
+      if (!assignment) return Promise.resolve(null);
+      return deletePostTag(assignment.rowId);
+    },
+    onMutate: async (tagId) => {
+      const previous = await snapshot();
+      patchEverySurface((nodes) =>
+        nodes.filter((node) => node?.tag?.rowId !== tagId),
+      );
+      return { previous };
+    },
+    onError: (_error, _tagId, context) => {
+      queryClient.setQueryData(queryKey, context?.previous);
+      invalidate();
+      toaster.error({ title: "Could not remove tag" });
+    },
+    onSettled: invalidate,
+  });
+
+  const assignedTagIds = (assignedTags ?? [])
+    .map((node) => node.tag?.rowId)
+    .filter((id): id is string => Boolean(id));
+
+  const isAssigned = (tagId: string) => assignedTagIds.includes(tagId);
+
+  /** Assign the tag if missing, otherwise unassign it. */
+  const toggleTag = (tagId: string) =>
+    isAssigned(tagId) ? unassign(tagId) : assign(tagId);
+
+  return {
+    assignedTags: (assignedTags ?? []) as PostTagAssignment[],
+    projectTags: (projectTags ?? []) as Tag[],
+    assignedTagIds,
+    isAssigned,
+    toggleTag,
+    isLoading: isLoadingAssigned || isLoadingProjectTags,
+  };
+};
+
+export default usePostTagEditor;

--- a/src/routes/_app/workspaces/$workspaceSlug/_layout/projects/$projectSlug/index.tsx
+++ b/src/routes/_app/workspaces/$workspaceSlug/_layout/projects/$projectSlug/index.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   createFileRoute,
   notFound,
+  redirect,
   stripSearchParams,
 } from "@tanstack/react-router";
 import { HiBolt, HiFolder, HiOutlineFolder } from "react-icons/hi2";
@@ -15,6 +16,7 @@ import ProjectLinks from "@/components/project/ProjectLinks";
 import { PostOrderBy } from "@/generated/graphql";
 import app from "@/lib/config/app.config";
 import { BASE_URL } from "@/lib/config/env.config";
+import { isStatusOnBoard } from "@/lib/constants/board.constant";
 import {
   freeTierFeedbackOptions,
   infiniteFeedbackOptions,
@@ -61,19 +63,24 @@ export const Route = createFileRoute(
   },
   loader: async ({
     context: { session, queryClient, organizationId },
-    params: { projectSlug },
+    params: { workspaceSlug, projectSlug },
     location,
   }) => {
     const { search, excludedStatuses, tags, orderBy } =
       projectSearchSchema.parse(location.search);
 
-    const { projects } = await queryClient.ensureQueryData({
-      ...projectOptions({
-        organizationId,
-        projectSlug,
+    // project gates the page; statuses seed the board's default status filter.
+    // Both are independent, so fetch them together.
+    const [{ projects }, statusData] = await Promise.all([
+      queryClient.ensureQueryData({
+        ...projectOptions({ organizationId, projectSlug }),
+        revalidateIfStale: true,
       }),
-      revalidateIfStale: true,
-    });
+      queryClient.ensureQueryData({
+        ...projectStatusesOptions({ organizationId }),
+        revalidateIfStale: true,
+      }),
+    ]);
 
     if (!projects?.nodes.length) throw notFound();
 
@@ -87,13 +94,36 @@ export const Route = createFileRoute(
     const projectId = project.rowId;
     const projectName = project.name;
 
+    // On first entry (no explicit status filter), hide terminal statuses
+    // (Completed / Closed) by default so resolved items don't bury open
+    // feedback. Seeding the URL keeps every consumer (list query key, pills,
+    // optimistic updates) in sync; since filters aren't loader deps, in-session
+    // toggles (including "show all") are preserved.
+    if (!excludedStatuses.length) {
+      const defaultHidden = (statusData?.statusTemplates?.nodes ?? [])
+        .filter(
+          (status): status is NonNullable<typeof status> =>
+            !!status &&
+            !isStatusOnBoard({
+              name: status.name,
+              showOnBoard: status.showOnBoard,
+            }),
+        )
+        .map((status) => status.displayName)
+        .sort();
+
+      if (defaultHidden.length) {
+        throw redirect({
+          to: "/workspaces/$workspaceSlug/projects/$projectSlug",
+          params: { workspaceSlug, projectSlug },
+          search: { search, tags, orderBy, excludedStatuses: defaultHidden },
+        });
+      }
+    }
+
     await Promise.all([
       queryClient.ensureQueryData({
         ...statusBreakdownOptions({ projectId }),
-        revalidateIfStale: true,
-      }),
-      queryClient.ensureQueryData({
-        ...projectStatusesOptions({ organizationId }),
         revalidateIfStale: true,
       }),
       queryClient.ensureQueryData(projectMetricsOptions({ projectId })),


### PR DESCRIPTION
## Description

Two UX improvements plus a small footer addition.

### Inline tag editing
A reusable, searchable, multi-select `TagPicker` (Ark Combobox) that stays open so several tags can be set in one go, backed by a shared `usePostTagEditor` hook that optimistically patches every cache a post appears in (detail, infinite lists, by-id/by-number). Surfaced on the detail page (replacing the one-at-a-time menu), in the edit dialog (lazy-loaded while open), and inline on feedback cards across the list/grid and roadmap board for any signed-in user.

### Hide resolved statuses on the board by default
Terminal statuses (Completed / Closed) are filtered off the board by default so resolved items don't bury open feedback, one toggle away via the existing pills. Mirrors the `showOnRoadmap` pattern: a name-based heuristic plus a per-status `showOnBoard` override, with an admin "Board" toggle next to "Roadmap" in status settings. The board loader seeds the default-hidden statuses into the URL on entry; since filters aren't loader deps, in-session toggles (including "show all") persist and every consumer (list query key, pills, optimistic updates) stays consistent. Roadmap/changelog untouched.

> Requires backfeed-api#102 (the `showOnBoard` column) to be deployed first.

### Footer
Adds a Threads link alongside Discord / GitHub / X.

## Test Steps

1. On a feedback card (list, grid, roadmap), click the inline "Tag" control; search, toggle multiple tags, confirm chips update instantly everywhere without reopening
2. Open the edit dialog; confirm a Tags field is present and edits apply immediately
3. Load a project board; confirm Completed/Closed posts are hidden and their pills read as off; toggle one on and confirm those posts appear; "All" shows everything
4. In project settings, flip a status's "Board" toggle and confirm it changes whether that status shows on the board by default
5. Confirm the footer shows a Threads icon linking to the @omnidotdev profile