### PR TITLE
chore: SEO/perf hardening rollup + feedback search perf and duplicate-status

### DIFF
--- a/src/components/feedback/PossibleDuplicates.tsx
+++ b/src/components/feedback/PossibleDuplicates.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link, useParams } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 
+import StatusBadge from "@/components/core/StatusBadge";
 import { similarPostsOptions } from "@/lib/options/similarPosts";
 
 interface Props {
@@ -36,7 +37,7 @@ const PossibleDuplicates = ({ projectId, content }: Props) => {
       </p>
       <ul className="flex flex-col gap-1">
         {similar.map((post) => (
-          <li key={post.id}>
+          <li key={post.id} className="flex items-center gap-2">
             <Link
               to="/workspaces/$workspaceSlug/projects/$projectSlug/$feedbackId"
               params={{
@@ -44,11 +45,19 @@ const PossibleDuplicates = ({ projectId, content }: Props) => {
                 projectSlug: projectSlug as string,
                 feedbackId: post.number ? String(post.number) : post.id,
               }}
-              className="text-[var(--colors-brand-primary)] hover:underline"
+              className="truncate text-[var(--colors-brand-primary)] hover:underline"
             >
               {post.number ? `#${post.number} ` : ""}
               {post.title ?? "Untitled"}
             </Link>
+            {/* surface the status so an already-completed/closed match reads as
+                resolved rather than something still open to duplicate */}
+            {post.status && (
+              <StatusBadge
+                status={post.status}
+                className="shrink-0 px-2 py-0.5"
+              />
+            )}
           </li>
         ))}
       </ul>

--- a/src/components/project/ProjectFeedback.tsx
+++ b/src/components/project/ProjectFeedback.tsx
@@ -7,7 +7,7 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { LuPlus } from "react-icons/lu";
 import useInfiniteScroll from "react-infinite-scroll-hook";
@@ -317,30 +317,42 @@ const ProjectFeedback = () => {
   // keepPreviousData list until the refetch returns. Mirrors the server filters:
   // hide excluded statuses (always keep status-less posts), match the search
   // against the title only, and require any of the selected tags
-  const searchQuery = searchInput.trim().toLowerCase();
+  // defer the live search text so the expensive client-side filter and full
+  // FeedbackCard list re-render happen at low priority. keystrokes commit the
+  // input update immediately while the list catches up on an interruptible
+  // render, keeping typing smooth even with many posts loaded
+  const deferredSearch = useDeferredValue(searchInput);
+  const searchQuery = deferredSearch.trim().toLowerCase();
 
-  const visiblePosts = (posts ?? []).filter((post) => {
-    const displayName = post?.statusTemplate?.displayName;
-    if (displayName && excludedStatuses.includes(displayName)) return false;
-    if (searchQuery && !post?.title?.toLowerCase().includes(searchQuery))
-      return false;
-    if (tags.length) {
-      const postTagIds = new Set(
-        (post?.postTags?.nodes ?? []).map((node) => node?.tag?.rowId),
-      );
-      if (!tags.some((tagId) => postTagIds.has(tagId))) return false;
-    }
-    return true;
-  });
+  const visiblePosts = useMemo(
+    () =>
+      (posts ?? []).filter((post) => {
+        const displayName = post?.statusTemplate?.displayName;
+        if (displayName && excludedStatuses.includes(displayName)) return false;
+        if (searchQuery && !post?.title?.toLowerCase().includes(searchQuery))
+          return false;
+        if (tags.length) {
+          const postTagIds = new Set(
+            (post?.postTags?.nodes ?? []).map((node) => node?.tag?.rowId),
+          );
+          if (!tags.some((tagId) => postTagIds.has(tagId))) return false;
+        }
+        return true;
+      }),
+    [posts, excludedStatuses, searchQuery, tags],
+  );
 
-  const allPosts = [
-    ...(showPendingFeedback
-      ? pendingFeedback.filter((feedback) =>
-          feedback.title?.toLowerCase().includes(searchQuery),
-        )
-      : []),
-    ...visiblePosts,
-  ];
+  const allPosts = useMemo(
+    () => [
+      ...(showPendingFeedback
+        ? pendingFeedback.filter((feedback) =>
+            feedback.title?.toLowerCase().includes(searchQuery),
+          )
+        : []),
+      ...visiblePosts,
+    ],
+    [showPendingFeedback, pendingFeedback, searchQuery, visiblePosts],
+  );
 
   const [loaderRef, { rootRef }] = useInfiniteScroll({
     // include the next-page fetch so the hook knows a load is in progress and

--- a/src/generated/graphql.sdk.ts
+++ b/src/generated/graphql.sdk.ts
@@ -2502,6 +2502,13 @@ export type NotificationActor = {
   username?: Maybe<Scalars['String']['output']>;
 };
 
+/** A lightweight signal that the current user received a notification. */
+export type NotificationEvent = {
+  __typename?: 'NotificationEvent';
+  id?: Maybe<Scalars['UUID']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+};
+
 export type NotificationPreference = {
   __typename?: 'NotificationPreference';
   /** Email me when a post I reported or upvoted changes status. */
@@ -8140,6 +8147,13 @@ export type StringFilter = {
   startsWith?: InputMaybe<Scalars['String']['input']>;
   /** Starts with the specified string (case-insensitive). */
   startsWithInsensitive?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The root subscription type: contains realtime events you can subscribe to with the `subscription` operation. */
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Fires when the current user receives a new notification. */
+  notificationReceived?: Maybe<NotificationEvent>;
 };
 
 export type Tag = {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -2501,6 +2501,13 @@ export type NotificationActor = {
   username?: Maybe<Scalars['String']['output']>;
 };
 
+/** A lightweight signal that the current user received a notification. */
+export type NotificationEvent = {
+  __typename?: 'NotificationEvent';
+  id?: Maybe<Scalars['UUID']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+};
+
 export type NotificationPreference = {
   __typename?: 'NotificationPreference';
   /** Email me when a post I reported or upvoted changes status. */
@@ -8139,6 +8146,13 @@ export type StringFilter = {
   startsWith?: InputMaybe<Scalars['String']['input']>;
   /** Starts with the specified string (case-insensitive). */
   startsWithInsensitive?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The root subscription type: contains realtime events you can subscribe to with the `subscription` operation. */
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Fires when the current user receives a new notification. */
+  notificationReceived?: Maybe<NotificationEvent>;
 };
 
 export type Tag = {

--- a/src/lib/graphql/codegen.config.ts
+++ b/src/lib/graphql/codegen.config.ts
@@ -1,9 +1,13 @@
-import { API_GRAPHQL_URL } from "../config/env.config";
-
 import type { CodegenConfig } from "@graphql-codegen/cli";
 import type { Types } from "@graphql-codegen/plugin-helpers";
 
 type GraphQLCodegenConfig = Types.ConfiguredOutput;
+
+// offline schema source: the API's committed SDL, generated from the database
+// (no running server or introspection needed). Override with GRAPHQL_SCHEMA_URL
+// to point at a live endpoint if ever required
+const LOCAL_SCHEMA_PATH =
+  "../backfeed-api/src/generated/graphql/schema.graphql";
 
 /**
  * Shared plugins across the generated GraphQL Codegen artifacts.
@@ -36,7 +40,7 @@ const sharedConfig: GraphQLCodegenConfig["config"] = {
  * GraphQL Code Generator configuration. This generates various artifacts based on the GraphQL schema.
  */
 const graphqlCodegenConfig: CodegenConfig = {
-  schema: API_GRAPHQL_URL,
+  schema: process.env.GRAPHQL_SCHEMA_URL || LOCAL_SCHEMA_PATH,
   documents: "src/lib/graphql/**/*.graphql",
   // suppress non-zero exit code if there are no documents to generate
   ignoreNoDocuments: true,

--- a/src/lib/options/similarPosts.ts
+++ b/src/lib/options/similarPosts.ts
@@ -7,6 +7,8 @@ export interface SimilarPost {
   number: number | null;
   title: string | null;
   score: number;
+  /** Current status of the candidate (null when the post has no status). */
+  status: { displayName: string; color: string | null } | null;
 }
 
 interface SimilarPostsData {
@@ -26,6 +28,10 @@ const SIMILAR_POSTS_QUERY = `
       number
       title
       score
+      status {
+        displayName
+        color
+      }
     }
   }
 `;


### PR DESCRIPTION
## Description

##### Task link: N/A

Rollup on the `chore/seo-perf-hardening` branch. Most recent work in this PR:

- **perf(feedback):** keep the project search input responsive while typing. The live search text fed the client-side post filter directly, so every keystroke synchronously re-filtered and re-rendered the whole (unmemoized) `FeedbackCard` list, blocking input on large boards. The filter now reads a `useDeferredValue` copy of the input and the derived lists are memoized, so keystrokes commit at high priority while the list reconciles as an interruptible render. The API request was already debounced and is unchanged.
- **feat(feedback):** show a `StatusBadge` on possible-duplicate suggestions in the composer so an already completed/closed match reads as resolved rather than something still open to duplicate. Requests the new `SimilarPost.status` field.

Also included on this branch (earlier commits): offline-schema codegen, SEO hardening (canonical/structured data/headers/cookie link), a11y contrast fixes, coral theme fixes, and workspace roster/label polish.

> [!IMPORTANT]
> The possible-duplicate status change selects `SimilarPost.status`, which only exists after backfeed-api PR #103 deploys. **Merge and deploy backfeed-api#103 before this merges to master** (app auto-deploys on merge), otherwise the `similarPosts` query fails validation against the live API and the possible-duplicates panel breaks.

## Test Steps

1. `bun run check` / typecheck clean.
2. Open a project board with many posts and type quickly in the search box: input stays responsive, list filters without lag.
3. Open the create-feedback composer and type a title matching an existing post: the "Possible duplicates" panel shows each match with a status badge; a completed/closed match is clearly labeled.
