### PR TITLE
chore(deps): bump @omnidotdev/providers to 5909b95

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@lexical/markdown": "0.39.0",
         "@lexical/react": "^0.39.0",
         "@lexical/rich-text": "^0.39.0",
-        "@omnidotdev/providers": "github:omnidotdev/providers#94513ca",
+        "@omnidotdev/providers": "github:omnidotdev/providers#5909b95",
         "@omnidotdev/thornberry": "github:omnidotdev/thornberry#4549481",
         "@tanstack/react-form": "^1.27.7",
         "@tanstack/react-query": "^5.90.16",
@@ -607,7 +607,7 @@
 
     "@npmcli/redact": ["@npmcli/redact@4.0.0", "", {}, "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q=="],
 
-    "@omnidotdev/providers": ["@omnidotdev/providers@github:omnidotdev/providers#94513ca", { "dependencies": { "ajv": "^8.18.0", "jose": "^6.1.3" }, "peerDependencies": { "@aws-sdk/client-s3": ">=3.0.0", "@aws-sdk/s3-request-presigner": ">=3.0.0", "@envelop/types": ">=5.0.0", "@escape.tech/graphql-armor": ">=3.0.0", "@iggy.rs/sdk": ">=1.0.0", "@openfeature/server-sdk": ">=1.0.0", "@tanstack/query-core": ">=5.0.0", "ajv": ">=8.0.0", "graphile-export": ">=1.0.0-rc.0", "postgraphile": ">=5.0.0-rc.0", "react": ">=19.0.0", "unleash-client": ">=6.0.0" }, "optionalPeers": ["@aws-sdk/client-s3", "@aws-sdk/s3-request-presigner", "@envelop/types", "@escape.tech/graphql-armor", "@iggy.rs/sdk", "@openfeature/server-sdk", "@tanstack/query-core", "ajv", "graphile-export", "postgraphile", "react", "unleash-client"] }, "omnidotdev-providers-94513ca", "sha512-CXRmj6imca28Mfijfkeeb435DWsL65JNB3zceWfqofDs/YgktZcWKX2HIvnSKWONzbcSO4CoIlIau2f99LONcQ=="],
+    "@omnidotdev/providers": ["@omnidotdev/providers@github:omnidotdev/providers#5909b95", { "dependencies": { "ajv": "^8.18.0", "jose": "^6.1.3" }, "peerDependencies": { "@aws-sdk/client-s3": ">=3.0.0", "@aws-sdk/s3-request-presigner": ">=3.0.0", "@envelop/types": ">=5.0.0", "@escape.tech/graphql-armor": ">=3.0.0", "@iggy.rs/sdk": ">=1.0.0", "@openfeature/server-sdk": ">=1.0.0", "@tanstack/query-core": ">=5.0.0", "ajv": ">=8.0.0", "graphile-export": ">=1.0.0-rc.0", "postgraphile": ">=5.0.0-rc.0", "react": ">=19.0.0", "unleash-client": ">=6.0.0" }, "optionalPeers": ["@aws-sdk/client-s3", "@aws-sdk/s3-request-presigner", "@envelop/types", "@escape.tech/graphql-armor", "@iggy.rs/sdk", "@openfeature/server-sdk", "@tanstack/query-core", "ajv", "graphile-export", "postgraphile", "react", "unleash-client"] }, "omnidotdev-providers-5909b95", "sha512-NuroNrcb7gjh+4RHdSPJE3w614BtoPd3P9zk3TyIs0MxtfLXgo6Op7PcHUAU6Gl4zlhVKrhQekvjL7kt5P3Ktw=="],
 
     "@omnidotdev/thornberry": ["@omnidotdev/thornberry@github:omnidotdev/thornberry#4549481", { "peerDependencies": { "@ark-ui/react": ">=5.0.0", "@lexical/html": ">=0.39.0", "@lexical/link": ">=0.39.0", "@lexical/list": ">=0.39.0", "@lexical/markdown": ">=0.39.0", "@lexical/react": ">=0.39.0", "@lexical/rich-text": ">=0.39.0", "@unpic/react": ">=1.0.0", "@xyflow/react": ">=12.0.0", "cmdk": ">=1.0.0", "isomorphic-dompurify": ">=3.0.0", "lexical": ">=0.39.0", "lucide-react": ">=0.500.0", "react": ">=19.0.0", "react-dom": ">=19.0.0", "react-hotkeys-hook": ">=5.0.0" } }, "omnidotdev-thornberry-4549481", "sha512-hQqv9+wKHLndqcD/uqv7o5bNVYIWogBtH7NvtC+xTm+FuCr2BK6OXjse2piu7O6KYfr5+OJKNvKtuZqjuGva9w=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@lexical/markdown": "0.39.0",
     "@lexical/react": "^0.39.0",
     "@lexical/rich-text": "^0.39.0",
-    "@omnidotdev/providers": "github:omnidotdev/providers#94513ca",
+    "@omnidotdev/providers": "github:omnidotdev/providers#5909b95",
     "@omnidotdev/thornberry": "github:omnidotdev/thornberry#4549481",
     "@tanstack/react-form": "^1.27.7",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION
## Summary

Bumps `@omnidotdev/providers` to `5909b95`, picking up the `getAuth` **single-flight refresh** + **degrade-on-rotation-race** fix so backfeed stops force-logging-out users when a page-load request burst races refresh-token rotation.

Pairs with the Gatekeeper rotation reuse grace window (omnidotdev/gatekeeper-app#73).