### PR TITLE
fix(avatar): use object-cover so non-square avatars aren't clipped

### DIFF
--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -60,7 +60,7 @@ const AvatarImage = ({
       }
     }}
     className={cn(
-      "aspect-square size-full opacity-0 transition-opacity duration-300 ease-out data-[state=visible]:opacity-100",
+      "aspect-square size-full object-cover opacity-0 transition-opacity duration-300 ease-out data-[state=visible]:opacity-100",
       className,
     )}
     alt="Avatar"


### PR DESCRIPTION
## Summary
Non-square user avatars were being clipped/squished, reported on mobile in comments on individual item pages.

## Root cause
`AvatarImage` rendered with the default `object-fit: fill`, so a non-square source photo is stretched to fill the 32x32 circular frame. Verified in the running app (a 240x120 source rendered squished; the flex-layout theory was ruled out by measurement).

## Change
Add `object-cover` to `AvatarImage` so images fill the frame preserving aspect ratio.

## Testing
- tsc + biome clean
- Verified in dev: object-fit resolves to `cover`, applied in the DOM

Note: the same defect exists in the shared Thornberry avatar (this file is a drifted fork); fixing it there is a follow-up.