### PR TITLE
style(account): make sign-out icon red

### DIFF
--- a/src/components/layout/AccountInformation.tsx
+++ b/src/components/layout/AccountInformation.tsx
@@ -119,7 +119,7 @@ const AccountInformation = () => {
               <MenuItem
                 value="logout"
                 onClick={handleLogout}
-                className="text-primary [&_svg]:text-primary dark:text-[var(--colors-brand-primary-400)] dark:[&_svg]:text-[var(--colors-brand-primary-400)]"
+                className="text-primary [&_svg]:text-destructive dark:text-[var(--colors-brand-primary-400)]"
               >
                 <FiLogOut />
                 {app.auth.signOut.label}
@@ -153,7 +153,7 @@ const AccountInformation = () => {
             <Button
               variant="outline"
               onClick={handleLogout}
-              className="border-primary text-primary [&_svg]:text-primary dark:text-[var(--colors-brand-primary-400)] dark:[&_svg]:text-[var(--colors-brand-primary-400)]"
+              className="border-primary text-primary [&_svg]:text-destructive dark:text-[var(--colors-brand-primary-400)]"
             >
               <FiLogOut />
               {app.auth.signOut.label}


### PR DESCRIPTION
## Summary

Colors the sign-out icon red (`text-destructive`, the repo's existing destructive token) in both places it renders: the profile dropdown item and the mobile collapsible button. Also drops the `dark:` brand-primary overrides on the icon so it reads red in light and dark. Label and border stay brand-primary.

## Testing

Visual/className change only; no logic affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)