### PR TITLE
fix(feedback): show pointer cursor on status update pills

### DIFF
--- a/src/components/feedback/StatusUpdateComposer.tsx
+++ b/src/components/feedback/StatusUpdateComposer.tsx
@@ -188,7 +188,7 @@ const StatusUpdateComposer = ({
               type="button"
               onClick={() => setTargetStatusId(status.rowId)}
               className={cn(
-                "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-sm transition-colors",
+                "inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-2.5 py-1 text-sm transition-colors",
                 isSelected
                   ? "border-transparent bg-muted font-medium"
                   : "border-border-subtle text-muted-foreground hover:bg-muted/60",


### PR DESCRIPTION
## Summary

Adds `cursor-pointer` to the status-selection pills in the admin status-update composer. Tailwind v4 defaults `<button>` to `cursor: default`, so the clickable status badges lacked a pointer cursor.

## Testing

Visual/className change only; no logic affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)